### PR TITLE
feat: add iframe store services connection, allows shared store acros…

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,9 @@ Get the public profile of a given address
 | address | <code>String</code> | An ethereum address |
 | opts | <code>Object</code> | Optional parameters |
 | opts.addressServer | <code>String</code> | URL of the Address Server |
-| opts.ipfsOptions | <code>Object</code> | A ipfs options object to pass to the js-ipfs constructor |
+| opts.ipfs | <code>Object</code> | A js-ipfs ipfs object |
 | opts.orbitPath | <code>String</code> | A custom path for orbitdb storage |
+| opts.iframeStore | <code>Boolean</code> | Use iframe for storage, allows shared store across domains. Default true when run in browser. |
 
 <a name="Box.openBox"></a>
 
@@ -241,9 +242,10 @@ Opens the user space associated with the given address
 | opts | <code>Object</code> | Optional parameters |
 | opts.consentCallback | <code>function</code> | A function that will be called when the user has consented to opening the box |
 | opts.pinningNode | <code>String</code> | A string with an ipfs multi-address to a 3box pinning node |
-| opts.ipfsOptions | <code>Object</code> | A ipfs options object to pass to the js-ipfs constructor |
+| opts.ipfs | <code>Object</code> | A js-ipfs ipfs object |
 | opts.orbitPath | <code>String</code> | A custom path for orbitdb storage |
 | opts.addressServer | <code>String</code> | URL of the Address Server |
+| opts.iframeStore | <code>Boolean</code> | Use iframe for storage, allows shared store across domains. Default true when run in browser. |
 
 <a name="Box.isLoggedIn"></a>
 

--- a/example/index.html
+++ b/example/index.html
@@ -65,7 +65,6 @@
       </div>
     </div>
   </body>
-  <script src="https://unpkg.com/ipfs/dist/index.min.js"></script>
   <script type="text/javascript" src="../dist/3box.js"></script>
   <script type="text/javascript" src="index.js"></script>
 

--- a/example/index.html
+++ b/example/index.html
@@ -65,6 +65,7 @@
       </div>
     </div>
   </body>
+  <script src="https://unpkg.com/ipfs/dist/index.min.js"></script>
   <script type="text/javascript" src="../dist/3box.js"></script>
   <script type="text/javascript" src="index.js"></script>
 

--- a/example/index.html
+++ b/example/index.html
@@ -3,7 +3,7 @@
 <html>
   <head>
     <title>3box Demo</title>
-    <script type="text/javascript" src="../dist/3box.js"></script>
+
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
   </head>
 
@@ -65,7 +65,7 @@
       </div>
     </div>
   </body>
-
+  <script type="text/javascript" src="../dist/3box.js"></script>
   <script type="text/javascript" src="index.js"></script>
 
 </html>

--- a/example/index.js
+++ b/example/index.js
@@ -7,6 +7,12 @@ bopen.addEventListener('click', event => {
     preload: { enabled: false }
   }
 
+  /**
+   *  This uses a local ipfs-js instance and local orbitdb cache instead of the
+   *  shared iframe storage available at 3box.io. Easier for testing and differing
+   *  configs. But in production you will get the best performance by using the
+   *  default iframe configuration.
+   */
   const ipfs = new window.Ipfs(IPFS_OPTIONS)
   const opts = { ipfs, iframeStore: false }
 
@@ -14,6 +20,7 @@ bopen.addEventListener('click', event => {
     console.log('Sync Complete')
     updateProfileData(window.box)
   }
+
   window.ethereum.enable().then(addresses => {
     Box.openBox(addresses[0],  window.ethereum, opts).then(box => {
       box.onSyncDone(syncComplete)

--- a/example/index.js
+++ b/example/index.js
@@ -1,10 +1,21 @@
 bopen.addEventListener('click', event => {
+
+  const IPFS_OPTIONS = {
+    EXPERIMENTAL: {
+      pubsub: true
+    },
+    preload: { enabled: false }
+  }
+
+  const ipfs = new window.Ipfs(IPFS_OPTIONS)
+  const opts = { ipfs, iframeStore: false }
+
   const syncComplete = (res) => {
     console.log('Sync Complete')
     updateProfileData(window.box)
   }
   window.ethereum.enable().then(addresses => {
-    Box.openBox(addresses[0],  window.ethereum).then(box => {
+    Box.openBox(addresses[0],  window.ethereum, opts).then(box => {
       box.onSyncDone(syncComplete)
       window.box = box
       console.log(box)
@@ -44,7 +55,7 @@ bopen.addEventListener('click', event => {
 
 getProfile.addEventListener('click', () => {
   console.log(ethAddr.value)
-  Box.getProfile(ethAddr.value).then(profile => {
+  Box.getProfile(ethAddr.value, opts).then(profile => {
     console.log(profile)
     Object.entries(profile).map(kv => {
       getProfileData.innerHTML +=kv[0] + ': ' + kv[1] + '<br />'

--- a/example/index.js
+++ b/example/index.js
@@ -1,28 +1,12 @@
 bopen.addEventListener('click', event => {
 
-  const IPFS_OPTIONS = {
-    EXPERIMENTAL: {
-      pubsub: true
-    },
-    preload: { enabled: false }
-  }
-
-  /**
-   *  This uses a local ipfs-js instance and local orbitdb cache instead of the
-   *  shared iframe storage available at 3box.io. Easier for testing and differing
-   *  configs. But in production you will get the best performance by using the
-   *  default iframe configuration.
-   */
-  const ipfs = new window.Ipfs(IPFS_OPTIONS)
-  const opts = { ipfs, iframeStore: false }
-
   const syncComplete = (res) => {
     console.log('Sync Complete')
     updateProfileData(window.box)
   }
 
   window.ethereum.enable().then(addresses => {
-    Box.openBox(addresses[0],  window.ethereum, opts).then(box => {
+    Box.openBox(addresses[0],  window.ethereum, {}).then(box => {
       box.onSyncDone(syncComplete)
       window.box = box
       console.log(box)
@@ -62,7 +46,7 @@ bopen.addEventListener('click', event => {
 
 getProfile.addEventListener('click', () => {
   console.log(ethAddr.value)
-  Box.getProfile(ethAddr.value, opts).then(profile => {
+  Box.getProfile(ethAddr.value, {}).then(profile => {
     console.log(profile)
     Object.entries(profile).map(kv => {
       getProfileData.innerHTML +=kv[0] + ': ' + kv[1] + '<br />'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "3box",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2210,6 +2210,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "argsarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/argsarray/-/argsarray-0.0.1.tgz",
+      "integrity": "sha1-bnIHtOzbObCviDA/pa4ivajfYcs="
+    },
     "argv-tools": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
@@ -3279,6 +3284,11 @@
         }
       }
     },
+    "callbackify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/callbackify/-/callbackify-1.1.0.tgz",
+      "integrity": "sha1-0qNphtKKppcUUmwREgm+65l50x4="
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -3992,6 +4002,11 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
+    },
+    "d64": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/d64/-/d64-1.0.0.tgz",
+      "integrity": "sha1-QAKofoUMv8n52XBrYPymE6MzbpA="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -7535,6 +7550,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
+    "has-localstorage": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-localstorage/-/has-localstorage-1.0.1.tgz",
+      "integrity": "sha1-/mJAbEdn+9bXhNrGkFkoEIuClxs="
+    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -7748,24 +7768,13 @@
         "promisify-es6": "^1.0.3"
       }
     },
-    "hyperdiff": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/hyperdiff/-/hyperdiff-2.0.5.tgz",
-      "integrity": "sha512-AzYOBJ4RowO3cT7mGtlZVCnHRlYUDVnVA1gLNY7IiWbpxg3UUWjMAeoD/B+h1LRd0OyXLnVV+fhmlBVhAKO+aQ==",
+    "humble-localstorage": {
+      "version": "1.4.2",
+      "resolved": "http://registry.npmjs.org/humble-localstorage/-/humble-localstorage-1.4.2.tgz",
+      "integrity": "sha1-0Fqw1SbE7b3b98amDfb/WAUoNGk=",
       "requires": {
-        "debug": "~3.1.0",
-        "lodash.clonedeep": "~4.5.0",
-        "lodash.pullat": "~4.6.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "has-localstorage": "^1.0.1",
+        "localstorage-memory": "^1.0.1"
       }
     },
     "iconv-lite": {
@@ -8594,6 +8603,32 @@
         "dicer": "^0.2.5"
       }
     },
+    "ipfs-postmsg-proxy": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/ipfs-postmsg-proxy/-/ipfs-postmsg-proxy-3.1.1.tgz",
+      "integrity": "sha512-SfBUODRZcGxdESOHx/wqQ+JoS149N1nFCWnjK5N9JZ3K4sDam0e6+JTLrty2laphcjpsHPbFAtE47HMueh56iQ==",
+      "requires": {
+        "big.js": "^5.1.2",
+        "callbackify": "^1.1.0",
+        "cids": "^0.5.3",
+        "ipfs-block": "^0.7.1",
+        "ipld-dag-pb": "^0.14.4",
+        "is-pull-stream": "0.0.0",
+        "is-stream": "^1.1.0",
+        "multiaddr": "^5.0.0",
+        "peer-id": "^0.11.0",
+        "peer-info": "^0.14.1",
+        "postmsg-rpc": "^2.4.0",
+        "prepost": "^1.1.0",
+        "pull-abortable": "^4.1.1",
+        "pull-defer": "^0.2.2",
+        "pull-postmsg-stream": "^1.2.0",
+        "pull-stream": "^3.6.8",
+        "pull-stream-to-stream": "^1.3.4",
+        "shortid": "^2.2.8",
+        "stream-to-pull-stream": "^1.7.2"
+      }
+    },
     "ipfs-pubsub-1on1": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/ipfs-pubsub-1on1/-/ipfs-pubsub-1on1-0.0.4.tgz",
@@ -8608,17 +8643,6 @@
       "integrity": "sha512-/6YJZn3dBbDUxopetJhgU65uAhOiz77CCTTZqEt4zk6s+r2t5+sYLIqO+1vX6IN3Bx2Hpf8iBdyt8JCkuq/zwg==",
       "requires": {
         "p-forever": "^1.0.1"
-      }
-    },
-    "ipfs-pubsub-room": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ipfs-pubsub-room/-/ipfs-pubsub-room-1.4.0.tgz",
-      "integrity": "sha512-OhH60+cBRGca6Eko9rWCr0OTZyBl0HCbdx003iK9XIfsdXurWpMY/Qkk994lF8BjU8rxJsqkJi8KBlLn0YUAWg==",
-      "requires": {
-        "hyperdiff": "^2.0.5",
-        "lodash.clonedeep": "^4.5.0",
-        "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.8"
       }
     },
     "ipfs-repo": {
@@ -11858,6 +11882,45 @@
         }
       }
     },
+    "localstorage-down": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/localstorage-down/-/localstorage-down-0.6.7.tgz",
+      "integrity": "sha1-0Hmak7MebF+lGI7AYkLrHM6dbRU=",
+      "requires": {
+        "abstract-leveldown": "0.12.3",
+        "argsarray": "0.0.1",
+        "buffer-from": "^0.1.1",
+        "d64": "^1.0.0",
+        "humble-localstorage": "^1.4.2",
+        "inherits": "^2.0.1",
+        "tiny-queue": "0.2.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "0.12.3",
+          "resolved": "http://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.3.tgz",
+          "integrity": "sha1-EWsexcdxDvei1XBnaLvbREC+EHA=",
+          "requires": {
+            "xtend": "~3.0.0"
+          }
+        },
+        "buffer-from": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+        },
+        "xtend": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+        }
+      }
+    },
+    "localstorage-memory": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/localstorage-memory/-/localstorage-memory-1.0.3.tgz",
+      "integrity": "sha512-t9P8WB6DcVttbw/W4PIE8HOqum8Qlvx5SjR6oInwR9Uia0EEmyUeBh7S+weKByW+l/f45Bj4L/dgZikGFDM6ng=="
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -11896,11 +11959,6 @@
       "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
       "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
       "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -12011,11 +12069,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.pullallwith/-/lodash.pullallwith-4.7.0.tgz",
       "integrity": "sha1-ZX5CAHENi1nWlO5SE2Yq4FEdEXA="
-    },
-    "lodash.pullat": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.pullat/-/lodash.pullat-4.6.0.tgz",
-      "integrity": "sha1-vfrPDiCf0n+WXnEfplp3SoTTAmE="
     },
     "lodash.range": {
       "version": "3.2.0",
@@ -13277,11 +13330,11 @@
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
     },
     "orbit-db": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/orbit-db/-/orbit-db-0.19.9.tgz",
-      "integrity": "sha512-Ts83RKS7Vo0b4UUe6zC3gw4QHx6AsKuuZ/FROk0afl6AdWZrBTnV6v4tfrP1gV5aM6QD6NM3juzNPovRmU7Jkg==",
+      "version": "git://github.com/orbitdb/orbit-db.git#dddb271a84e2455cd1e574909781c398a317e06a",
+      "from": "git://github.com/orbitdb/orbit-db.git#dddb271",
       "requires": {
         "ipfs-pubsub-1on1": "~0.0.4",
+        "localstorage-down": "^0.6.7",
         "logplease": "^1.2.14",
         "multihashes": "^0.4.12",
         "orbit-db-cache": "~0.2.4",
@@ -13304,6 +13357,15 @@
         "leveldown": "~3.0.2",
         "logplease": "^1.2.14",
         "mkdirp": "^0.5.1"
+      }
+    },
+    "orbit-db-cache-postmsg-proxy": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/orbit-db-cache-postmsg-proxy/-/orbit-db-cache-postmsg-proxy-0.0.4.tgz",
+      "integrity": "sha512-7WnpTJgUFkuGMlHrzFzRt38j4+XzaFWV8ADs2PRZ0HONHoE6deo+LWxTVVtNq6v7gMEE4UccUc5MiPMqE2dIjw==",
+      "requires": {
+        "orbit-db-cache": "^0.2.4",
+        "postmsg-rpc": "^2.4.0"
       }
     },
     "orbit-db-counterstore": {
@@ -14010,6 +14072,14 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "postmsg-rpc": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/postmsg-rpc/-/postmsg-rpc-2.4.0.tgz",
+      "integrity": "sha512-adGH2zGSxhCUOfUfAXdRn4tgZVWauaSP2X8on+g7uBA45sxkzORL1oia95eXZtcZk5Sp4JTZmDFOTe+D24avBQ==",
+      "requires": {
+        "shortid": "^2.2.8"
+      }
+    },
     "prebuild-install": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
@@ -14058,6 +14128,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
+    "prepost": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/prepost/-/prepost-1.1.0.tgz",
+      "integrity": "sha512-HhwOYePY0JXrbqAHm0fGWdSBFqGAMCJvdTaKGxO7uO6S0cbdxXeTnMWDkgAJDS+6kXATaV3n0C0EGI6tR+nqQA=="
     },
     "preserve": {
       "version": "0.2.0",
@@ -14352,6 +14427,15 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/pull-pause/-/pull-pause-0.0.2.tgz",
       "integrity": "sha1-GdRb6PqmFfpVbxSpb9czRiw3+6M="
+    },
+    "pull-postmsg-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pull-postmsg-stream/-/pull-postmsg-stream-1.2.0.tgz",
+      "integrity": "sha512-wpuu5iEFYRr0tJvnzvo3Q8b0Nopzy5FqnCYjrhL/YY5goTNre+paB4qHghMvbB7JSjo717f5XCGRTzTL2sXv7w==",
+      "requires": {
+        "postmsg-rpc": "^2.4.0",
+        "prepost": "^1.1.0"
+      }
     },
     "pull-pushable": {
       "version": "2.2.0",
@@ -16925,6 +17009,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tiny-each-async/-/tiny-each-async-2.0.3.tgz",
       "integrity": "sha1-jru/1tYpXxNwAD+7NxYq/loKUdE="
+    },
+    "tiny-queue": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-queue/-/tiny-queue-0.2.0.tgz",
+      "integrity": "sha1-xJ/LXIdVW+G0pd9+uHEB1beLydw="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ipfs-postmsg-proxy": "^3.1.1",
     "js-sha256": "^0.9.0",
     "muport-core": "^0.4.1",
-    "orbit-db": "^0.19.9",
+    "orbit-db": "git://github.com/orbitdb/orbit-db.git#dddb271",
     "orbit-db-cache-postmsg-proxy": "0.0.4",
     "store": "^2.0.12",
     "xmlhttprequest": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -43,13 +43,10 @@
     "@babel/runtime": "^7.1.2",
     "bip39": "^2.5.0",
     "ipfs": "^0.32.2",
-    "ipfs-api": "^24.0.0",
     "ipfs-postmsg-proxy": "^3.1.1",
-    "ipfs-pubsub-room": "^1.4.0",
     "js-sha256": "^0.9.0",
     "muport-core": "^0.4.1",
     "orbit-db": "^0.19.9",
-    "orbit-db-cache": "^0.2.4",
     "orbit-db-cache-postmsg-proxy": "0.0.4",
     "store": "^2.0.12",
     "xmlhttprequest": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -44,10 +44,13 @@
     "bip39": "^2.5.0",
     "ipfs": "^0.32.2",
     "ipfs-api": "^24.0.0",
+    "ipfs-postmsg-proxy": "^3.1.1",
     "ipfs-pubsub-room": "^1.4.0",
     "js-sha256": "^0.9.0",
     "muport-core": "^0.4.1",
     "orbit-db": "^0.19.9",
+    "orbit-db-cache": "^0.2.4",
+    "orbit-db-cache-postmsg-proxy": "0.0.4",
     "store": "^2.0.12",
     "xmlhttprequest": "^1.8.0"
   },

--- a/src/3box.js
+++ b/src/3box.js
@@ -4,7 +4,6 @@ const localstorage = require('store')
 const OrbitDB = require('orbit-db')
 const Pubsub = require('orbit-db-pubsub')
 const OrbitDBCacheProxy = require('orbit-db-cache-postmsg-proxy').Client
-const OrbitDBCache = require('orbit-db-cache')
 const { createProxyClient } = require('ipfs-postmsg-proxy')
 
 const PublicStore = require('./publicStore')
@@ -66,7 +65,7 @@ class Box {
 
     const keystore = new OrbitdbKeyAdapter(this._muportDID)
     // console.time('new OrbitDB')
-    const cache = (opts.iframeStore && !!cacheProxy) ? cacheProxy : OrbitDBCache
+    const cache = (opts.iframeStore && !!cacheProxy) ? cacheProxy : null
     this._orbitdb = new OrbitDB(this._ipfs, opts.orbitPath, { keystore, cache })
     // console.timeEnd('new OrbitDB')
     globalIPFS = this._ipfs
@@ -162,7 +161,7 @@ class Box {
       orbitdb = globalOrbitDB
       usingGlobalIPFS = true
     } else {
-      const cache = (opts.iframeStore && !!cacheProxy) ? cacheProxy : OrbitDBCache
+      const cache = (opts.iframeStore && !!cacheProxy) ? cacheProxy : null
       orbitdb = new OrbitDB(ipfs, opts.orbitPath, { cache })
     }
 

--- a/src/3box.js
+++ b/src/3box.js
@@ -14,7 +14,8 @@ const utils = require('./utils')
 const ADDRESS_SERVER_URL = 'https://beta.3box.io/address-server'
 const PINNING_NODE = '/dnsaddr/ipfs.3box.io/tcp/443/wss/ipfs/QmZvxEpiVNjmNbEKyQGvFzAY1BwmGuuvdUTmcTstQPhyVC'
 const PINNING_ROOM = '3box-pinning'
-const IFRAME_STORE_URL = 'http://localhost:30001/'
+const IFRAME_STORE_VERSION = '0.0.2'
+const IFRAME_STORE_URL = `https://iframe.3box.io/${IFRAME_STORE_VERSION}/iframe.html`
 
 let globalIPFS, globalOrbitDB, ipfsProxy, cacheProxy
 
@@ -144,7 +145,8 @@ class Box {
    * @param     {Boolean}   opts.iframeStore        Use iframe for storage, allows shared store across domains. Default true when run in browser.
    * @return    {Object}                            a json object with the profile for the given address
    */
-  static async getProfile (address, opts = { iframeStore: true }) {
+  static async getProfile (address, opts) {
+    opts = Object.assign({ iframeStore: true }, opts)
     const serverUrl = opts.addressServer || ADDRESS_SERVER_URL
     const rootStoreAddress = await getRootStoreAddress(serverUrl, address.toLowerCase())
     let usingGlobalIPFS = false
@@ -223,9 +225,10 @@ class Box {
    * @param     {Boolean}           opts.iframeStore        Use iframe for storage, allows shared store across domains. Default true when run in browser.
    * @return    {Box}                                       the 3Box instance for the given address
    */
-  static async openBox (address, ethereumProvider, opts = { iframeStore: true }) {
+  static async openBox (address, ethereumProvider, opts) {
+    opts = Object.assign({ iframeStore: true }, opts)
     const normalizedAddress = address.toLowerCase()
-    console.time('-- openBox --')
+    // console.time('-- openBox --')
     let muportDID
     let serializedMuDID = localstorage.get('serializedMuDID_' + normalizedAddress)
     if (serializedMuDID) {
@@ -249,10 +252,10 @@ class Box {
     // console.time('new 3box')
     const box = new Box(muportDID, ethereumProvider, opts)
     // console.timeEnd('new 3box')
-    console.time('load 3box')
+    // console.time('load 3box')
     await box._load(opts)
-    console.timeEnd('load 3box')
-    console.timeEnd('-- openBox --')
+    // console.timeEnd('load 3box')
+    // console.timeEnd('-- openBox --')
     return box
   }
 

--- a/src/3box.js
+++ b/src/3box.js
@@ -20,7 +20,7 @@ let globalIPFS, globalOrbitDB, ipfsProxy, cacheProxy
 
 if (typeof window !== 'undefined' && typeof document !== 'undefined') {
   const iframe = document.createElement('iframe')
-  iframe.src = 'http://localhost:30001/'   // TODO may want pass arg, but also want anticipate default and load iframe as soon as page loads since loading ipfs takes a bit
+  iframe.src = 'http://localhost:30001/' // TODO may want pass arg, but also want anticipate default and load iframe as soon as page loads since loading ipfs takes a bit
   iframe.style = 'width:0; height:0; border:0; border:none !important'
   document.body.appendChild(iframe)
   // Create proxy clients that talks to the iframe
@@ -82,6 +82,7 @@ class Box {
       if (peer === pinningNode.split('/').pop()) {
         // console.timeEnd('opening pinning room, pinning node joined')
         // console.log('broadcasting odb-address')
+
         this._pubsub.publish(PINNING_ROOM, { type: 'PIN_DB', odbAddress: rootStoreAddress })
       }
     }
@@ -143,7 +144,7 @@ class Box {
    * @param     {Boolean}   opts.iframeStore        Use iframe for storage, allows shared store across domains. Default true when run in browser.
    * @return    {Object}                            a json object with the profile for the given address
    */
-  static async getProfile (address, opts = {iframeStore: true}) {
+  static async getProfile (address, opts = { iframeStore: true }) {
     const serverUrl = opts.addressServer || ADDRESS_SERVER_URL
     const rootStoreAddress = await getRootStoreAddress(serverUrl, address.toLowerCase())
     let usingGlobalIPFS = false
@@ -222,7 +223,7 @@ class Box {
    * @param     {Boolean}           opts.iframeStore        Use iframe for storage, allows shared store across domains. Default true when run in browser.
    * @return    {Box}                                       the 3Box instance for the given address
    */
-  static async openBox (address, ethereumProvider, opts = {iframeStore: true}) {
+  static async openBox (address, ethereumProvider, opts = { iframeStore: true }) {
     const normalizedAddress = address.toLowerCase()
     console.time('-- openBox --')
     let muportDID
@@ -323,7 +324,7 @@ class Box {
   async close () {
     await this._orbitdb.stop()
     await this._pubsub.disconnect()
-    await this._ipfs.stop()
+    // await this._ipfs.stop()
     globalOrbitDB = null
     globalIPFS = null
   }
@@ -356,9 +357,11 @@ async function initIPFS (ipfs, iframeStore) {
     if (!ipfs && !ipfsProxy) reject(new Error('No IPFS object configured and no default available for environment'))
     if (!!ipfs && iframeStore) console.log('Warning: iframeStore true, orbit db cache in iframe, but the given ipfs object is being used, and may not be running in same iframe.')
     if (ipfs) {
-       ipfs.on('ready', () => resolve(ipfs))
+      resolve(ipfs)
+      // TODO assume reayd object??
+      // ipfs.on('ready', () => resolve(ipfs))
     } else {
-      // TODO get is ready from iframe
+      // TODO is this already from iframe? does it wait to return messages until ready?
       resolve(ipfsProxy)
     }
     // ipfs.on('error', error => {

--- a/src/3box.js
+++ b/src/3box.js
@@ -15,19 +15,10 @@ const utils = require('./utils')
 const ADDRESS_SERVER_URL = 'https://beta.3box.io/address-server'
 const PINNING_NODE = '/dnsaddr/ipfs.3box.io/tcp/443/wss/ipfs/QmZvxEpiVNjmNbEKyQGvFzAY1BwmGuuvdUTmcTstQPhyVC'
 const PINNING_ROOM = '3box-pinning'
-const IPFS_OPTIONS = {
-  EXPERIMENTAL: {
-    pubsub: true
-  },
-  preload: { enabled: false },
-  config: {
-    Bootstrap: [ ]
-  }
-}
 
 let globalIPFS, globalOrbitDB, ipfsProxy, cacheProxy
 
-if (typeof window !== 'undefined') {
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
   const iframe = document.createElement('iframe')
   iframe.src = 'http://localhost:30001/'   // TODO may want pass arg, but also want anticipate default and load iframe as soon as page loads since loading ipfs takes a bit
   iframe.style = 'width:0; height:0; border:0; border:none !important'
@@ -364,13 +355,16 @@ async function initIPFS (ipfs, iframeStore) {
   return new Promise((resolve, reject) => {
     if (!ipfs && !ipfsProxy) reject(new Error('No IPFS object configured and no default available for environment'))
     if (!!ipfs && iframeStore) console.log('Warning: iframeStore true, orbit db cache in iframe, but the given ipfs object is being used, and may not be running in same iframe.')
-    ipfs ? resolve(ipfs) : resolve(ipfsProxy)
+    if (ipfs) {
+       ipfs.on('ready', () => resolve(ipfs))
+    } else {
+      // TODO get is ready from iframe
+      resolve(ipfsProxy)
+    }
     // ipfs.on('error', error => {
     //   console.error(error)
     //   reject(error)
     // })
-    // TODO need to pass message to iframe to wait until ready
-    // ipfs.on('ready', () => resolve(ipfs))
   })
 }
 

--- a/src/3box.js
+++ b/src/3box.js
@@ -15,12 +15,13 @@ const utils = require('./utils')
 const ADDRESS_SERVER_URL = 'https://beta.3box.io/address-server'
 const PINNING_NODE = '/dnsaddr/ipfs.3box.io/tcp/443/wss/ipfs/QmZvxEpiVNjmNbEKyQGvFzAY1BwmGuuvdUTmcTstQPhyVC'
 const PINNING_ROOM = '3box-pinning'
+const IFRAME_STORE_URL = 'http://localhost:30001/'
 
 let globalIPFS, globalOrbitDB, ipfsProxy, cacheProxy
 
 if (typeof window !== 'undefined' && typeof document !== 'undefined') {
   const iframe = document.createElement('iframe')
-  iframe.src = 'http://localhost:30001/' // TODO may want pass arg, but also want anticipate default and load iframe as soon as page loads since loading ipfs takes a bit
+  iframe.src = IFRAME_STORE_URL
   iframe.style = 'width:0; height:0; border:0; border:none !important'
   document.body.appendChild(iframe)
   // Create proxy clients that talks to the iframe

--- a/src/__tests__/3box.test.js
+++ b/src/__tests__/3box.test.js
@@ -104,6 +104,7 @@ const MOCK_HASH_SERVER = 'address-server'
 
 describe('3Box', () => {
   let ipfs, pubsub, boxOpts, ipfsBox, box
+  jest.setTimeout(30000)
 
   beforeEach(async () => {
     if (!ipfs) ipfs = await testUtils.initIPFS(true)

--- a/src/__tests__/3box.test.js
+++ b/src/__tests__/3box.test.js
@@ -2,6 +2,7 @@ const testUtils = require('./testUtils')
 const OrbitDB = require('orbit-db')
 const Pubsub = require('orbit-db-pubsub')
 const jsdom = require('jsdom')
+const IPFS = require('ipfs')
 global.window = new jsdom.JSDOM().window
 
 jest.mock('muport-core', () => {
@@ -99,25 +100,40 @@ jest.mock('../utils', () => {
 })
 const mockedUtils = require('../utils')
 const MOCK_HASH_SERVER = 'address-server'
-const boxOpts = {
-  ipfsOptions: {
-    EXPERIMENTAL: {
-      pubsub: true
-    },
-    repo: './tmp/ipfs1/'
+
+const IPFS_OPTIONS = {
+  EXPERIMENTAL: {
+    pubsub: true
   },
+  preload: { enabled: false },
+  repo: './tmp/ipfs1/'
+}
+
+
+const IPFS_OPTIONS_2 = {
+  EXPERIMENTAL: {
+    pubsub: true
+  },
+  preload: { enabled: false },
+  repo: './tmp/ipfs3/'
+}
+
+const ipfs = new IPFS(IPFS_OPTIONS)
+const ipfs2 = new IPFS(IPFS_OPTIONS_2)
+const opts = { ipfs, iframeStore: false }
+
+
+const boxOpts = {
+  ipfs: ipfs,
   orbitPath: './tmp/orbitdb1',
-  addressServer: MOCK_HASH_SERVER
+  addressServer: MOCK_HASH_SERVER,
+  iframeStore: false
 }
 const boxOpts2 = {
-  ipfsOptions: {
-    EXPERIMENTAL: {
-      pubsub: true
-    },
-    repo: './tmp/ipfs3/'
-  },
+  ipfs: ipfs2,
   orbitPath: './tmp/orbitdb2',
-  addressServer: MOCK_HASH_SERVER
+  addressServer: MOCK_HASH_SERVER,
+  iframeStore: false
 }
 
 const Box = require('../3box')

--- a/src/__tests__/keyValueStore.test.js
+++ b/src/__tests__/keyValueStore.test.js
@@ -118,8 +118,8 @@ describe('KeyValueStore', () => {
     })
   })
 
-  afterAll(async () => {
-    await orbitdb.stop()
-    await ipfs.stop()
-  })
+  // afterAll(async () => {
+  //   await orbitdb.stop()
+  //   await ipfs.stop()
+  // })
 })

--- a/src/__tests__/testUtils.js
+++ b/src/__tests__/testUtils.js
@@ -4,8 +4,19 @@ const CONF = {
   EXPERIMENTAL: {
     pubsub: true
   },
-  repo: './tmp/ipfs1/'
+  repo: './tmp/ipfs4/',
+  config: {
+    Addresses: {
+      Swarm: [
+        '/ip4/127.0.0.1/tcp/4006',
+        '/ip4/127.0.0.1/tcp/4007/ws'
+      ],
+      API: '/ip4/127.0.0.1/tcp/5004',
+      Gateway: '/ip4/127.0.0.1/tcp/9092'
+    }
+  }
 }
+
 const ALT_CONF = {
   EXPERIMENTAL: {
     pubsub: true


### PR DESCRIPTION
### What 
This PR allows stores/data to be share across domains, resulting in less syncs and quicker starts. Initial attempts saw openBox time decrease by more than 50% when using same size data set

* 4-6 secs (when not opened on a domain yet) decreasing to 2.3-2.4  💨 🎉 
*  3 secs (when already cached on a domain) decreasing to 2.3-2.4 (idk why this changed yet 🤷‍♂️) 

### How 
Stores are shared across domains by running the storage layers in an iframe and using an RPC interface to connect the 3box library to the storage services running in the iframe. The iframe runs 'js-ipfs'  and [orbit-db-cache](https://github.com/orbitdb/orbit-db-cache) as a service. Then a proxy instance of both the cache and ipfs is used in 3box-js using [orbit-db-cache-postmsg-proxy](https://github.com/3box/orbit-db-cache-postmsg-proxy) and [ipfs-postmsg-proxy](https://github.com/ipfs-shipyard/ipfs-postmsg-proxy).

The iframe can be found here [3box-js-iframe](https://github.com/3box/3box-js-iframe). 

### Related

This PR is also connected to the following new repos and PRs:
* [orbit-db-cache-postmsg-proxy](https://github.com/3box/orbit-db-cache-postmsg-proxy)
* [3box-js-iframe](https://github.com/3box/3box-js-iframe)
* [PR for Cache option in OrbitDB](https://github.com/orbitdb/orbit-db/pull/507)

### Remaining TODOs:

- [x] Test in Node and make sure it also works there. Goal was to keep iframe optional, need better default when not using iframe. i.e provide ipfs, but remove from webpack build for browser build
- [x] Also iframe optional in browser?
- [ ] ~~Error thrown after sync, have not looked into where it is coming from yet~~
- [ ]~~Could Iframe load be faster? at least initial page loads faster now due to much smaller lib size, but then lags for iframe load.~~
- [x] ~~Maybe allow iframe path as option. Difficult because we want to load the iframe on page load since takes a little while. While passing an option would require for it to wait until it is called by app using lib. (Hard set to http://localhost:30001/ for testing right now)~~ Will be task in future, making iframe optional is sufficient for now.
- [ ] ~~Deploy iframe [3box-js-iframe](https://github.com/3box/3box-js-iframe). Could be at a space on our domain or on ipfs. Although we would likely want and a fixed reference. So that iframe can be updated without the all the libs needing updates.~~
- [x] Tests? Current test failure will be fixed, once first TODO is covered 
- [x] Change example. Either need how to on how to also run iframe locally, reference where ever we deploy it, or related 2nd TODO, run without iframe. 
- [ ] ~~Test once iframe deployed, to make sure there is no cross domain issues.~~

### Try it out

In this repo: 
```bash
npm run example:start
```

In [3box-js-iframe](https://github.com/3box/3box-js-iframe) repo at the same time:
```bash
npm run example:start
```