### PR TITLE
fix: libp2p/ipfs boostrap node option

### DIFF
--- a/src/3box.js
+++ b/src/3box.js
@@ -17,7 +17,10 @@ const IPFS_OPTIONS = {
   EXPERIMENTAL: {
     pubsub: true
   },
-  preload: { enabled: false }
+  preload: { enabled: false },
+  config: {
+    Bootstrap: [ ]
+  }
 }
 
 let globalIPFS


### PR DESCRIPTION
Likely the solution to https://github.com/3box/3box-js/issues/203. 203 shouldn't really be issue and it likely an issue in ipfs/libp2p2, it looks like that when its trying to connect it fails, it keeps trying and runs out memory causing it to fail or the error is block something. But anyways bootstrap nodes not necessary right now, we know a node to connect to. 