### PR TITLE
fix: resolve sync promise if there are more entries locally than on p…

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## v1.2.2 - 2019-01-25
+* Fixes a bug where more entries locally compared to the pinning node would result in onSyncDone not getting called.
+
 ## v1.2.1 - 2019-01-17
 * Fixes bug in getVerifiedAccounts to work with earlier accounts #258
 * Fix to allow openBox to be called with no options

--- a/src/keyValueStore.js
+++ b/src/keyValueStore.js
@@ -51,7 +51,7 @@ class KeyValueStore {
   async _sync (numRemoteEntries) {
     this._requireLoad()
     // let toid = null
-    if (numRemoteEntries === this._db._oplog.values.length) return Promise.resolve()
+    if (numRemoteEntries <= this._db._oplog.values.length) return Promise.resolve()
     await new Promise((resolve, reject) => {
       if (!numRemoteEntries) {
         setTimeout(() => {
@@ -61,7 +61,7 @@ class KeyValueStore {
         }, 3000)
       }
       this._db.events.on('replicated', () => {
-        if (numRemoteEntries === this._db._oplog.values.length) resolve()
+        if (numRemoteEntries <= this._db._oplog.values.length) resolve()
       })
       /*
       this._db.events.on('replicate.progress', (_x, _y, _z, num, max) => {


### PR DESCRIPTION
…inning node

This should fix infinite onSyncDone!