### PR TITLE
Feat/refac configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
     "test": "rm -rf ./tmp ; jest --forceExit --detectOpenHandles --coverage --runInBand --testURL=\"http://localhost\"",
     "build:es5": "rm -rf ./lib; ./node_modules/.bin/babel src --out-dir lib --ignore=src/__tests__/,src/__mocks__/",
     "build:dist": "./node_modules/.bin/webpack --config webpack.config.js --mode=development",
+    "build:dist:dev": "./node_modules/.bin/webpack --config webpack.dev.config.js --mode=development",
     "build:dist:prod": "./node_modules/.bin/webpack --config webpack.config.js --mode=production --output-filename 3box.min.js",
     "build": "npm run build:es5; npm run build:dist; npm run build:dist:prod",
     "prepublishOnly": "npm run build; npm run generate-readme",
-    "example:start": "npm run build:dist; node example/server.js",
+    "example:start": "node example/server.js | npm run build:dist:dev ",
     "generate-readme": "cp readme-template.md README.md; ./node_modules/.bin/jsdoc2md -g none -d 3 src/*.js >> README.md"
   },
   "browser": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:dist:prod": "./node_modules/.bin/webpack --config webpack.config.js --mode=production --output-filename 3box.min.js",
     "build": "npm run build:es5; npm run build:dist; npm run build:dist:prod",
     "prepublishOnly": "npm run build; npm run generate-readme",
-    "example:start": "node example/server.js | npm run build:dist:dev ",
+    "example-server:start": "node example/server.js",
+    "example:start": "npm run build:dist; npm run example-server:start",
     "generate-readme": "cp readme-template.md README.md; ./node_modules/.bin/jsdoc2md -g none -d 3 src/*.js >> README.md"
   },
   "browser": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@babel/preset-react": "^7.0.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "^8.0.5",
+    "express": "^4.16.4",
     "ganache-cli": "^6.1.0",
     "ipfsd-ctl": "^0.40.1",
     "jest": "^23.6.0",

--- a/src/3box.js
+++ b/src/3box.js
@@ -13,24 +13,17 @@ const Verified = require('./verified')
 const Space = require('./space')
 const utils = require('./utils/index')
 const verifier = require('./utils/verifier')
+const config = require('./config.js')
 
-const ADDRESS_SERVER_URL = 'https://beta.3box.io/address-server'
-const PINNING_NODE = '/dnsaddr/ipfs.3box.io/tcp/443/wss/ipfs/QmZvxEpiVNjmNbEKyQGvFzAY1BwmGuuvdUTmcTstQPhyVC'
-const PINNING_ROOM = '3box-pinning'
+const ADDRESS_SERVER_URL = config.address_server_url
+const PINNING_NODE = config.pinning_node
+const PINNING_ROOM = config.pinning_room
 // const IFRAME_STORE_VERSION = '0.0.3'
 // const IFRAME_STORE_URL = `https://iframe.3box.io/${IFRAME_STORE_VERSION}/iframe.html`
-const IPFS_OPTIONS = {
-  EXPERIMENTAL: {
-    pubsub: true
-  },
-  preload: { enabled: false },
-  config: {
-    Bootstrap: [ ]
-  }
-}
+const IPFS_OPTIONS = config.ipfs_options
+const GRAPHQL_SERVER_URL = config.graphql_server_url
+const PROFILE_SERVER_URL = config.profile_server_url
 
-const GRAPHQL_SERVER_URL = 'https://aic67onptg.execute-api.us-west-2.amazonaws.com/develop/graphql'
-const PROFILE_SERVER_URL = 'https://ipfs.3box.io'
 
 let globalIPFS, globalOrbitDB // , ipfsProxy, cacheProxy, iframeLoadedPromise
 

--- a/src/3box.js
+++ b/src/3box.js
@@ -24,7 +24,6 @@ const IPFS_OPTIONS = config.ipfs_options
 const GRAPHQL_SERVER_URL = config.graphql_server_url
 const PROFILE_SERVER_URL = config.profile_server_url
 
-
 let globalIPFS, globalOrbitDB // , ipfsProxy, cacheProxy, iframeLoadedPromise
 
 /*

--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,11 @@
 const IFRAME_STORE_VERSION = '0.0.3'
 
 module.exports =  {
-  address_server_url: 'https://beta.3box.io/address-server',
-  pinning_node: '/dnsaddr/ipfs.3box.io/tcp/443/wss/ipfs/QmZvxEpiVNjmNbEKyQGvFzAY1BwmGuuvdUTmcTstQPhyVC',
-  pinning_room: '3box-pinning',
-  iframe_store_version: IFRAME_STORE_VERSION,
-  iframe_store_url: `https://iframe.3box.io/${IFRAME_STORE_VERSION}/iframe.html`,
+  address_server_url: process.env.ADDRESS_SERVER_URL || 'https://beta.3box.io/address-server',
+  pinning_node: process.env.PINNING_NODE || '/dnsaddr/ipfs.3box.io/tcp/443/wss/ipfs/QmZvxEpiVNjmNbEKyQGvFzAY1BwmGuuvdUTmcTstQPhyVC',
+  pinning_room: process.env.PINNING_ROOM || '3box-pinning',
+  iframe_store_version: process.env.IFRAME_STORE_VERSION || IFRAME_STORE_VERSION,
+  iframe_store_url: process.env.IFRAME_STORE_URL || `https://iframe.3box.io/${IFRAME_STORE_VERSION}/iframe.html`,
   ipfs_options: {
     EXPERIMENTAL: {
       pubsub: true
@@ -15,6 +15,6 @@ module.exports =  {
       Bootstrap: [ ]
     }
   },
-  graphql_server_url: 'https://aic67onptg.execute-api.us-west-2.amazonaws.com/develop/graphql',
-  profile_server_url: 'https://ipfs.3box.io'
+  graphql_server_url: process.env.GRAPHQL_SERVER_URL || 'https://aic67onptg.execute-api.us-west-2.amazonaws.com/develop/graphql',
+  profile_server_url: process.env.PROFILE_SERVER_URL || 'https://ipfs.3box.io'
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,20 @@
+const IFRAME_STORE_VERSION = '0.0.3'
+
+module.exports =  {
+  address_server_url: 'https://beta.3box.io/address-server',
+  pinning_node: '/dnsaddr/ipfs.3box.io/tcp/443/wss/ipfs/QmZvxEpiVNjmNbEKyQGvFzAY1BwmGuuvdUTmcTstQPhyVC',
+  pinning_room: '3box-pinning',
+  iframe_store_version: IFRAME_STORE_VERSION,
+  iframe_store_url: `https://iframe.3box.io/${IFRAME_STORE_VERSION}/iframe.html`,
+  ipfs_options: {
+    EXPERIMENTAL: {
+      pubsub: true
+    },
+    preload: { enabled: false },
+    config: {
+      Bootstrap: [ ]
+    }
+  },
+  graphql_server_url: 'https://aic67onptg.execute-api.us-west-2.amazonaws.com/develop/graphql',
+  profile_server_url: 'https://ipfs.3box.io'
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 const IFRAME_STORE_VERSION = '0.0.3'
 
-module.exports =  {
+module.exports = {
   address_server_url: process.env.ADDRESS_SERVER_URL || 'https://beta.3box.io/address-server',
   pinning_node: process.env.PINNING_NODE || '/dnsaddr/ipfs.3box.io/tcp/443/wss/ipfs/QmZvxEpiVNjmNbEKyQGvFzAY1BwmGuuvdUTmcTstQPhyVC',
   pinning_room: process.env.PINNING_ROOM || '3box-pinning',

--- a/src/config.js
+++ b/src/config.js
@@ -16,5 +16,8 @@ module.exports = {
     }
   },
   graphql_server_url: process.env.GRAPHQL_SERVER_URL || 'https://aic67onptg.execute-api.us-west-2.amazonaws.com/develop/graphql',
-  profile_server_url: process.env.PROFILE_SERVER_URL || 'https://ipfs.3box.io'
+  profile_server_url: process.env.PROFILE_SERVER_URL || 'https://ipfs.3box.io',
+  muport_ipfs_host: process.env.MUPORT_IPFS_HOST || 'ipfs.infura.io',
+  muport_ipfs_port: process.env.MUPORT_IPFS_PORT || 5001,
+  muport_ipfs_protocol: process.env.MUPORT_IPFS_PROTOCOL || 'https'
 }

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,0 +1,23 @@
+// const path = require('path');
+const webpack = require('webpack')
+
+// const webpackBaseConfig = require('webpack.base.config.js')
+//
+// webpackBaseConfig['plugins'] = [
+//   new webpack.EnvironmentPlugin(['PINNING_NODE'])
+// ]
+
+module.exports = Object.assign(require('./webpack.config.js'), {
+  watch: true,
+  plugins: [
+    new webpack.EnvironmentPlugin([
+      'ADDRESS_SERVER_URL',
+      'PINNING_NODE',
+      'PINNING_ROOM',
+      'IFRAME_STORE_VERSION',
+      'IFRAME_STORE_URL',
+      'GRAPHQL_SERVER_URL',
+      'PROFILE_SERVER_URL',
+    ])
+  ]
+})

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -18,6 +18,9 @@ module.exports = Object.assign(require('./webpack.config.js'), {
       'IFRAME_STORE_URL',
       'GRAPHQL_SERVER_URL',
       'PROFILE_SERVER_URL',
+      'MUPORT_IPFS_HOST',
+      'MUPORT_IPFS_PORT',
+      'MUPORT_IPFS_PROTOCOL',
     ])
   ]
 })


### PR DESCRIPTION
This pr does the following:

- Move configs to single place 
- add env variables as an options
- allow those env variables to only be used in a dev build, all other build ignore env var and use defaults (primarily so that we don't accidentally publish with different env vars)
- creates a dev build that allows above, and runs in watch mode (auto rebuild)
- allows muport ipfs configs to be passed through