### PR TITLE
feat: onsync done for spaces

### DIFF
--- a/src/3box.js
+++ b/src/3box.js
@@ -131,8 +131,7 @@ class Box {
           hasResponse[pubStoreAddress] = true
         }
         if (spaceMessageFilterActive && data.odbAddress.includes('space') === true) {
-          const spaceName = data.odbAddress.split('/')[3].split('.')[2]
-          this.spacesPubSubMessages[spaceName] = data
+          this.spacesPubSubMessages[data.odbAddress] = data
         }
         if (syncPromises.length === 2) {
           const promises = syncPromises
@@ -347,8 +346,7 @@ class Box {
     if (!this.spaces[name]) {
       this.spaces[name] = new Space(name, this._3id, this._orbitdb, this._rootStore, this._ensurePinningNodeConnected.bind(this))
       try {
-        const entryMessage = this.spacesPubSubMessages[name]
-        opts = entryMessage ? Object.assign({ numEntries: entryMessage.numEntries }, opts) : opts
+        opts = Object.assign({ numEntriesMessages: this.spacesPubSubMessages }, opts)
         await this.spaces[name].open(opts)
       } catch (e) {
         console.log(e)

--- a/src/3box.js
+++ b/src/3box.js
@@ -68,6 +68,9 @@ class Box {
      * @property {Object} spaces            an object containing all open spaces indexed by their name.
      */
     this.spaces = {}
+
+    // local store of all pinning server pubsub messages seen related to spaces
+    this.spacesPubSubMessages = {}
   }
 
   async _load (opts = {}) {
@@ -117,6 +120,10 @@ class Box {
         if (data.odbAddress === pubStoreAddress && !hasResponse[pubStoreAddress]) {
           syncPromises.push(this.public._sync(data.numEntries))
           hasResponse[pubStoreAddress] = true
+        }
+        if (data.odbAddress.includes('space') === true) {
+          const spaceName = data.odbAddress.split('/')[3].split('.')[2]
+          this.spacesPubSubMessages[spaceName] = data
         }
         if (syncPromises.length === 2) {
           const promises = syncPromises
@@ -331,8 +338,11 @@ class Box {
     if (!this.spaces[name]) {
       this.spaces[name] = new Space(name, this._3id, this._orbitdb, this._rootStore, this._ensurePinningNodeConnected.bind(this))
       try {
+        const entryMessage = this.spacesPubSubMessages[name]
+        opts = entryMessage ? Object.assign({ numEntries: entryMessage.numEntries }, opts) : opts
         await this.spaces[name].open(opts)
       } catch (e) {
+        console.log(e)
         delete this.spaces[name]
       }
     } else if (opts.onSyncDone) {

--- a/src/__tests__/3box.test.js
+++ b/src/__tests__/3box.test.js
@@ -257,9 +257,9 @@ describe('3Box', () => {
   })
 
   it('should open spaces correctly', async () => {
-    let space1 = await box.openSpace('name1', 'myOpts')
+    let space1 = await box.openSpace('name1', {})
     expect(space1._name).toEqual('name1')
-    expect(space1.open).toHaveBeenCalledWith('myOpts')
+    expect(space1.open).toHaveBeenCalledWith(expect.any(Object))
     let opts = { onSyncDone: jest.fn() }
     let space2 = await box.openSpace('name1', opts)
     expect(space1).toEqual(space2)

--- a/src/keyValueStore.js
+++ b/src/keyValueStore.js
@@ -52,7 +52,8 @@ class KeyValueStore {
   async _sync (numRemoteEntries) {
     this._requireLoad()
     // let toid = null
-    if (numRemoteEntries <= this._db._oplog.values.length) return Promise.resolve()
+    const numEntriesDefined = !(numRemoteEntries === null || numRemoteEntries === undefined)
+    if (numEntriesDefined && numRemoteEntries <= this._db._oplog.values.length) return Promise.resolve()
     await new Promise((resolve, reject) => {
       if (!numRemoteEntries) {
         setTimeout(() => {

--- a/src/space.js
+++ b/src/space.js
@@ -24,10 +24,7 @@ class Space {
         this._rootStore.add({ odbAddress: spaceAddress })
       }
       const syncSpace = async () => {
-        // TODO - this logic isn't completely sound yet. Now it will just
-        // always resolve after three seconds. We need a way to get unsynced
-        // entries for the given store from the pinning node.
-        await this._store._sync()
+        await this._store._sync(opts.numEntries || null)
         if (opts.onSyncDone) opts.onSyncDone()
       }
       syncSpace()

--- a/src/space.js
+++ b/src/space.js
@@ -23,8 +23,9 @@ class Space {
       if (!entries.find(entry => entry.payload.value.odbAddress.indexOf(nameToSpaceName(this._name)) !== -1)) {
         this._rootStore.add({ odbAddress: spaceAddress })
       }
+      const numEntries = opts.numEntriesMessages ? opts.numEntriesMessages[spaceAddress].numEntries : undefined
       const syncSpace = async () => {
-        await this._store._sync(opts.numEntries)
+        await this._store._sync(numEntries)
         if (opts.onSyncDone) opts.onSyncDone()
       }
       syncSpace()

--- a/src/space.js
+++ b/src/space.js
@@ -24,7 +24,7 @@ class Space {
         this._rootStore.add({ odbAddress: spaceAddress })
       }
       const syncSpace = async () => {
-        await this._store._sync(opts.numEntries || null)
+        await this._store._sync(opts.numEntries)
         if (opts.onSyncDone) opts.onSyncDone()
       }
       syncSpace()


### PR DESCRIPTION
Implemented with minimal code diff, but this was also a good area for refactor. We should have two additional logical services, one that handles pubsub messages, on peers joining, and more importantly messages on response now that it is not only relevant to openbox, but also spaces, and they happen at differing times. Second we could probably have a logical service that handles syncing state across dbs/spaces. 

In the current implementation the pinDB message to the pinning server results in the pinning server opening all stores, including all spaces. We will likely want to change to this to open what is needed when it is needed.

We could also refactor some the code around open/load/sync as similar handling is need for both primary DBs and spaces, but code exist in two different places at the moment. 