### PR TITLE
feat(space): Implemented simple threads

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -77,6 +77,19 @@
           <p>
             <span id="spaceDataPriv"></span>
           </p>
+
+          <h3> Threads: </h3>
+          <input type="text" id="threadName" placeholder="Join thread by name">
+          <button id="joinThread" type="button" class="btn btn btn-primary" >Join thread</button>
+          <div id="posts" style="display: none;">
+            <h4> Posts: </h4>
+            <p>
+              <span id="threadData"></span>
+            </p>
+            <input type="text" id="postMsg" placeholder="Type your message">
+            <button id="postThread" type="button" class="btn btn btn-primary">Post</button>
+          </div>
+
         </div>
       </div>
 

--- a/example/index.js
+++ b/example/index.js
@@ -91,6 +91,31 @@ bopen.addEventListener('click', event => {
         })
       }
 
+      joinThread.addEventListener('click', () => {
+        const name = threadName.value
+        posts.style.display = 'block'
+        box.spaces[window.currentSpace].joinThread(name).then(thread => {
+          window.currentThread = thread
+          thread.onNewPost(post => {
+            threadData.innerHTML += post.author + ': <br />' + post.message + '<br /><br />'
+          })
+          updateThreadData()
+        })
+      })
+
+      const updateThreadData = () => {
+        threadData.innerHTML = ''
+        window.currentThread.getPosts().then(posts => {
+          posts.map(post => {
+            threadData.innerHTML += post.author + ': <br />' + post.message + '<br /><br />'
+          })
+        })
+      }
+
+      postThread.addEventListener('click', () => {
+        window.currentThread.post(postMsg.value)
+      })
+
       bclose.addEventListener('click', () => {
         logout(box)
       })

--- a/src/3box.js
+++ b/src/3box.js
@@ -408,12 +408,16 @@ class Box {
     }
   }
 
-  async _ensurePinningNodeConnected (odbAddress) {
+  async _ensurePinningNodeConnected (odbAddress, isThread) {
     const roomPeers = await this._ipfs.pubsub.peers(odbAddress)
     if (!roomPeers.find(p => p === this.pinningNode.split('/').pop())) {
       this._ipfs.swarm.connect(this.pinningNode, () => {})
       const rootStoreAddress = this._rootStore.address.toString()
-      this._pubsub.publish(PINNING_ROOM, { type: 'PIN_DB', odbAddress: rootStoreAddress })
+      if (isThread) {
+        this._pubsub.publish(PINNING_ROOM, { type: 'SYNC_DB', odbAddress, thread: true })
+      } else {
+        this._pubsub.publish(PINNING_ROOM, { type: 'PIN_DB', odbAddress: rootStoreAddress })
+      }
     }
   }
 

--- a/src/__tests__/testUtils.js
+++ b/src/__tests__/testUtils.js
@@ -71,7 +71,43 @@ const CONF_4 = {
     Bootstrap: []
   }
 }
-const CONFS = [CONF_1, CONF_2, CONF_3, CONF_4]
+
+const CONF_5 = {
+  EXPERIMENTAL: {
+    pubsub: true
+  },
+  repo: './tmp/ipfs7/',
+  config: {
+    Addresses: {
+      Swarm: [
+        '/ip4/127.0.0.1/tcp/4014',
+        '/ip4/127.0.0.1/tcp/4015/ws'
+      ],
+      API: '/ip4/127.0.0.1/tcp/5016',
+      Gateway: '/ip4/127.0.0.1/tcp/9095'
+    },
+    Bootstrap: []
+  }
+}
+
+const CONF_6 = {
+  EXPERIMENTAL: {
+    pubsub: true
+  },
+  repo: './tmp/ipfs8/',
+  config: {
+    Addresses: {
+      Swarm: [
+        '/ip4/127.0.0.1/tcp/4017',
+        '/ip4/127.0.0.1/tcp/4018/ws'
+      ],
+      API: '/ip4/127.0.0.1/tcp/5019',
+      Gateway: '/ip4/127.0.0.1/tcp/9096'
+    },
+    Bootstrap: []
+  }
+}
+const CONFS = [CONF_1, CONF_2, CONF_3, CONF_4, CONF_5, CONF_6]
 
 module.exports = {
   initIPFS: async (useAltConf) => {

--- a/src/__tests__/thread.test.js
+++ b/src/__tests__/thread.test.js
@@ -106,9 +106,14 @@ describe('Thread', () => {
       threadUser2 = new Thread(orbitdb2, THREAD2_NAME, THREEID2_MOCK, subscribeMock, ensureConnected)
       await threadUser2._load()
       // user1 posts and user2 receives
+      // done needed to not catch the write event
+      let done = false
       let postPromise = new Promise((resolve, reject) => {
         threadUser2.onNewPost(post => {
-          expect(post.message).toEqual(MSG1)
+          if (!done) {
+            expect(post.message).toEqual(MSG1)
+            done = true
+          }
           resolve()
         })
       })
@@ -117,6 +122,7 @@ describe('Thread', () => {
       expect(posts1[0].author).toEqual(THREEID1_MOCK.getDid())
       expect(posts1[0].message).toEqual(MSG1)
       await postPromise
+      threadUser2.onNewPost(() => {})
       await new Promise((resolve, reject) => { setTimeout(resolve, 500) })
       let posts2 = await threadUser2.getPosts()
       expect(posts2[0].author).toEqual(THREEID1_MOCK.getDid())

--- a/src/__tests__/thread.test.js
+++ b/src/__tests__/thread.test.js
@@ -1,0 +1,135 @@
+const utils = require('./testUtils')
+const Thread = require('../thread')
+const OrbitDB = require('orbit-db')
+const EC = require('elliptic').ec
+const ec = new EC('secp256k1')
+
+const THREAD1_NAME = '3box.thread.somespace.name1'
+const THREAD2_NAME = '3box.thread.somespace.name2'
+
+const MSG1 = 'message1'
+const MSG2 = 'message2'
+const MSG3 = 'message3'
+const MSG4 = 'message4'
+
+const THREEID1_MOCK = {
+  _mainKeyring: {
+    getDBKey: () => ec.keyFromPrivate('f917ac6883f88798a8ce39821fa523f2acd17c0ba80c724f219367e76d8f2c46')
+  },
+  getDid: () => 'did:3:mydid1'
+}
+const THREEID2_MOCK = {
+  _mainKeyring: {
+    getDBKey: () => ec.keyFromPrivate('f977777aaaaaaabbbbbbb9821fa523f2acd17c0ba80c724f219367e76d8f2c46')
+  },
+  getDid: () => 'did:3:mydid2'
+}
+
+const subscribeMock = jest.fn()
+
+describe('Thread', () => {
+  let ipfs
+  let orbitdb
+  let thread
+  let storeAddr
+  jest.setTimeout(20000)
+
+  beforeAll(async () => {
+    ipfs = await utils.initIPFS(4)
+    orbitdb = new OrbitDB(ipfs, './tmp/orbitdb4')
+  })
+
+  beforeEach(() => {
+    subscribeMock.mockClear()
+  })
+
+  it('creates thread correctly', async () => {
+    thread = new Thread(orbitdb, THREAD1_NAME, THREEID1_MOCK, subscribeMock)
+  })
+
+  it('should throw if not loaded', async () => {
+    expect(thread.post('key')).rejects.toThrow(/_load must/)
+    expect(thread.getPosts()).rejects.toThrow(/_load must/)
+    expect(thread.onNewPost(() => {})).rejects.toThrow(/_load must/)
+  })
+
+  it('should start with an empty db on load', async () => {
+    storeAddr = await thread._load()
+    expect(storeAddr.split('/')[3]).toEqual(THREAD1_NAME)
+    expect(await thread.getPosts()).toEqual([])
+  })
+
+  it('adding posts works as expected', async () => {
+    await thread.post(MSG1)
+    let posts = await thread.getPosts()
+    expect(posts[0].author).toEqual(THREEID1_MOCK.getDid())
+    expect(posts[0].message).toEqual(MSG1)
+    expect(subscribeMock).toHaveBeenCalledTimes(1)
+
+    await thread.post(MSG2)
+    posts = await thread.getPosts()
+    expect(posts[0].message).toEqual(MSG1)
+    expect(posts[1].message).toEqual(MSG2)
+    expect(subscribeMock).toHaveBeenCalledTimes(2)
+
+    await thread.post(MSG3)
+    posts = await thread.getPosts()
+    expect(posts[0].message).toEqual(MSG1)
+    expect(posts[1].message).toEqual(MSG2)
+    expect(posts[2].message).toEqual(MSG3)
+    expect(subscribeMock).toHaveBeenCalledTimes(3)
+  })
+
+  describe('multi user interaction', () => {
+    let threadUser1
+    let threadUser2
+    let ipfs2
+    let orbitdb2
+    beforeAll(async () => {
+      ipfs2 = await utils.initIPFS(5)
+      orbitdb2 = new OrbitDB(ipfs2, './tmp/orbitdb5')
+    })
+
+    it('syncs thread between users', async () => {
+      threadUser1 = new Thread(orbitdb, THREAD2_NAME, THREEID1_MOCK, subscribeMock)
+      await threadUser1._load()
+      threadUser2 = new Thread(orbitdb2, THREAD2_NAME, THREEID2_MOCK, subscribeMock)
+      await threadUser2._load()
+      // user1 posts and user2 receives
+      let postPromise = new Promise((resolve, reject) => {
+        threadUser2.onNewPost(post => {
+          expect(post.message).toEqual(MSG1)
+          resolve()
+        })
+      })
+      await threadUser1.post(MSG1)
+      let posts1 = await threadUser1.getPosts()
+      expect(posts1[0].author).toEqual(THREEID1_MOCK.getDid())
+      expect(posts1[0].message).toEqual(MSG1)
+      await postPromise
+      await new Promise((resolve, reject) => { setTimeout(resolve, 500) })
+      let posts2 = await threadUser2.getPosts()
+      expect(posts2[0].author).toEqual(THREEID1_MOCK.getDid())
+      expect(posts2[0].message).toEqual(MSG1)
+      expect(posts2[0].postId).toEqual(posts1[0].postId)
+
+      // user2 posts and user1 receives
+      postPromise = new Promise((resolve, reject) => {
+        threadUser1.onNewPost(post => {
+          expect(post.message).toEqual(MSG2)
+          resolve()
+        })
+      })
+      await threadUser2.post(MSG2)
+      posts2 = await threadUser2.getPosts()
+      expect(posts2[1].author).toEqual(THREEID2_MOCK.getDid())
+      expect(posts2[1].message).toEqual(MSG2)
+      await postPromise
+      await new Promise((resolve, reject) => { setTimeout(resolve, 500) })
+      posts1 = await threadUser1.getPosts()
+      expect(posts1[1].author).toEqual(THREEID2_MOCK.getDid())
+      expect(posts1[1].message).toEqual(MSG2)
+      expect(posts1[1].postId).toEqual(posts2[1].postId)
+    })
+  })
+})

--- a/src/space.js
+++ b/src/space.js
@@ -13,7 +13,8 @@ class Space {
   constructor (name, threeId, orbitdb, rootStore, ensureConnected) {
     this._name = name
     this._3id = threeId
-    this._store = new KeyValueStore(orbitdb, nameToSpaceName(this._name), ensureConnected, this._3id)
+    this._ensureConnected = ensureConnected
+    this._store = new KeyValueStore(orbitdb, nameToSpaceName(this._name), this._ensureConnected, this._3id)
     this._orbitdb = orbitdb
     this._activeThreads = {}
     this._rootStore = rootStore
@@ -62,7 +63,7 @@ class Space {
   async joinThread (name, opts = {}) {
     if (this._activeThreads[name]) return this._activeThreads[name]
     const subscribeFn = opts.noAutoSub ? () => {} : this.subscribeThread.bind(this, name)
-    const thread = new Thread(this._orbitdb, namesTothreadName(this._name, name), this._3id, subscribeFn)
+    const thread = new Thread(this._orbitdb, namesTothreadName(this._name, name), this._3id, subscribeFn, this._ensureConnected)
     await thread._load()
     this._activeThreads[name] = thread
     return thread

--- a/src/thread.js
+++ b/src/thread.js
@@ -2,11 +2,12 @@ class Thread {
   /**
    * Please use **space.joinThread** to get the instance of this class
    */
-  constructor (orbitdb, name, threeId, subscribe) {
+  constructor (orbitdb, name, threeId, subscribe, ensureConnected) {
     this._orbitdb = orbitdb
     this._name = name
     this._3id = threeId
     this._subscribe = subscribe
+    this._ensureConnected = ensureConnected
   }
 
   /**
@@ -18,6 +19,7 @@ class Thread {
   async post (message) {
     this._requireLoad()
     this._subscribe()
+    this._ensureConnected(this._address, true)
     return this._db.add({
       author: this._3id.getDid(),
       message,
@@ -74,7 +76,9 @@ class Thread {
       write: ['*']
     })
     await this._db.load()
-    return this._db.address.toString()
+    this._address = this._db.address.toString()
+    this._ensureConnected(this._address, true)
+    return this._address
   }
 
   _requireLoad () {

--- a/src/thread.js
+++ b/src/thread.js
@@ -1,0 +1,90 @@
+class Thread {
+  /**
+   * Please use **space.joinThread** to get the instance of this class
+   */
+  constructor (orbitdb, name, threeId, subscribe) {
+    this._orbitdb = orbitdb
+    this._name = name
+    this._3id = threeId
+    this._subscribe = subscribe
+  }
+
+  /**
+   * Post a message to the thread
+   *
+   * @param     {Object}    message                 The message
+   * @return    {String}                            The postId of the new post
+   */
+  async post (message) {
+    this._requireLoad()
+    this._subscribe()
+    return this._db.add({
+      author: this._3id.getDid(),
+      message,
+      timeStamp: new Date().getTime()
+    })
+  }
+
+  /**
+   * Returns an array of posts, based on the options.
+   * If hash not found when passing gt, gte, lt, or lte,
+   * the iterator will return all items (respecting limit and reverse).
+   *
+   * @param     {Object}    opts                    Optional parameters
+   * @param     {String}    opts.gt                 Greater than, takes an postId
+   * @param     {String}    opts.gte                Greater than or equal to, takes an postId
+   * @param     {String}    opts.lt                 Less than, takes an postId
+   * @param     {String}    opts.lte                Less than or equal to, takes an postId
+   * @param     {Integer}   opts.limit              Limiting the number of entries in result, defaults to -1 (no limit)
+   * @param     {Boolean}   opts.reverse            If set to true will result in reversing the result
+   *
+   * @return    {Array<Object>}                           true if successful
+   */
+  async getPosts (opts = {}) {
+    this._requireLoad()
+    if (!opts.limit) opts.limit = -1
+    return this._db.iterator(opts).collect().map(entry => {
+      let post = entry.payload.value
+      post.postId = entry.hash
+      return post
+    })
+  }
+
+  /**
+   * Register a function to be called for every new
+   * post that is received from the network.
+   * The function takes one parameter, which is the post
+   *
+   * @param     {Function}  newPostFn               The function that will get called
+   */
+  async onNewPost (newPostFn) {
+    this._requireLoad()
+    this._db.events.on('replicate.progress', (address, hash, entry) => {
+      let post = entry.payload.value
+      post.postId = hash
+      newPostFn(post)
+    })
+  }
+
+  async _load (odbAddress) {
+    // TODO - threads should use the space keyring once pairwise DIDs are implemented
+    const key = this._3id._mainKeyring.getDBKey()
+    this._db = await this._orbitdb.log(odbAddress || this._name, {
+      key,
+      write: ['*']
+    })
+    await this._db.load()
+    return this._db.address.toString()
+  }
+
+  _requireLoad () {
+    if (!this._db) throw new Error('_load must be called before interacting with the store')
+  }
+
+  async close () {
+    this._requireLoad()
+    await this._db.close()
+  }
+}
+
+module.exports = Thread


### PR DESCRIPTION
This is still a WIP but should work quite well already. There is a new `Thread` class. Instances of this class can be created using the Space api. 

Since threads are not added to the users rootstore we need a new way to announce the thread to the pinning node. To do this the new `SYNC_DB` message is used according to our updated pinning node spec. Note that this requires an update to our pinning node in order to function properly