### PR TITLE
fix: throw during fetch & return empty profile

### DIFF
--- a/src/3box.js
+++ b/src/3box.js
@@ -372,7 +372,11 @@ class Box {
         address_token: addressToken
       })
     } catch (err) {
-      throw new Error(err)
+      // we capture http errors (500, etc)
+      // see: https://github.com/3box/3box-js/pull/351
+      if (!err.statusCode) {
+        throw new Error(err)
+      }
     }
     return true
   }

--- a/src/api.js
+++ b/src/api.js
@@ -39,14 +39,12 @@ async function getSpace (address, name, serverUrl = PROFILE_SERVER_URL) {
 }
 
 async function getProfile (address, serverUrl = PROFILE_SERVER_URL) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const res = await utils.fetchJson(serverUrl + '/profile?address=' + encodeURIComponent(address))
-      resolve(res)
-    } catch (err) {
-      reject(err)
-    }
-  })
+  try {
+    // we await explicitly here to make sure the error is catch'd in the correct scope
+    return await utils.fetchJson(serverUrl + '/profile?address=' + encodeURIComponent(address))
+  } catch (err) {
+    return {} // empty profile
+  }
 }
 
 async function getProfiles (addressArray, opts = {}) {

--- a/src/api.js
+++ b/src/api.js
@@ -10,32 +10,24 @@ const ADDRESS_SERVER_URL = config.address_server_url
 async function getRootStoreAddress (identifier, serverUrl = ADDRESS_SERVER_URL) {
   // read orbitdb root store address from the 3box-address-server
   const res = await utils.fetchJson(serverUrl + '/odbAddress/' + identifier)
-  if (res.status === 'success') {
-    return res.data.rootStoreAddress
-  } else {
-    throw new Error(res.message)
-  }
+  return res.data.rootStoreAddress
 }
+
 async function listSpaces (address, serverUrl = PROFILE_SERVER_URL) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const res = await utils.fetchJson(serverUrl + '/list-spaces?address=' + encodeURIComponent(address))
-      resolve(res)
-    } catch (err) {
-      reject(err)
-    }
-  })
+  try {
+    // we await explicitly here to make sure the error is catch'd in the correct scope
+    return await utils.fetchJson(serverUrl + '/list-spaces?address=' + encodeURIComponent(address))
+  } catch (err) {
+    return []
+  }
 }
 
 async function getSpace (address, name, serverUrl = PROFILE_SERVER_URL) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const res = await utils.fetchJson(serverUrl + `/space?address=${encodeURIComponent(address)}&name=${encodeURIComponent(name)}`)
-      resolve(res)
-    } catch (err) {
-      reject(err)
-    }
-  })
+  try {
+    return await utils.fetchJson(serverUrl + `/space?address=${encodeURIComponent(address)}&name=${encodeURIComponent(name)}`)
+  } catch (err) {
+    return {}
+  }
 }
 
 async function getProfile (address, serverUrl = PROFILE_SERVER_URL) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -81,11 +81,23 @@ module.exports = {
     if (body) {
       opts = { body: JSON.stringify(body), method: 'POST', headers: { 'Content-Type': 'application/json' } }
     }
-    return (await fetch(url, opts)).json()
+    const r = await fetch(url, opts)
+
+    if (r.ok) {
+      return r.json()
+    } else {
+      throw new Error(`Invalid response (${r.status}) for query at ${url}`)
+    }
   },
 
   fetchText: async (url, opts) => {
-    return (await fetch(url, opts)).text()
+    const r = await fetch(url, opts)
+
+    if (r.ok) {
+      return r.text()
+    } else {
+      throw new Error(`Invalid response (${r.status}) for query at ${url}`)
+    }
   },
 
   sha256Multihash: str => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,6 +2,12 @@ const fetch = typeof window !== 'undefined' ? window.fetch : require('node-fetch
 const Multihash = require('multihashes')
 const sha256 = require('js-sha256').sha256
 
+const HTTPError = (status, message) => {
+  const e = new Error(message)
+  e.statusCode = status
+  return e
+}
+
 module.exports = {
   openBoxConsent: (fromAddress, ethereum) => {
     const text = 'This app wants to view and update your 3Box profile.'
@@ -86,7 +92,7 @@ module.exports = {
     if (r.ok) {
       return r.json()
     } else {
-      throw new Error(`Invalid response (${r.status}) for query at ${url}`)
+      throw HTTPError(r.status, `Invalid response (${r.status}) for query at ${url}`)
     }
   },
 
@@ -96,7 +102,7 @@ module.exports = {
     if (r.ok) {
       return r.text()
     } else {
-      throw new Error(`Invalid response (${r.status}) for query at ${url}`)
+      throw HTTPError(r.status, `Invalid response (${r.status}) for query at ${url}`)
     }
   },
 


### PR DESCRIPTION
- [x] _linkProfile => preserve behavior
- [x] _publishRootStore => preserve behavior
- [x] getRootStoreAddress => rethrow
- [x] listSpaces => catch and return an empty array
- [x] getSpace => catch and return an empty object
- [x] getProfiles => rethrow (it's a list of profile so a "global" 404 error should be raised as an error).
- [x] getProfile => empty profile
