### PR TITLE
Allow Muport DIDs (in the cached version)

### DIFF
--- a/src/3box.js
+++ b/src/3box.js
@@ -231,6 +231,10 @@ class Box {
   }
 
   static async _getProfileOrbit (address, opts = {}) {
+    if (utils.isMuportDID(address)) {
+      throw new Error('DID are supported in the cached version only')
+    }
+
     // opts = Object.assign({ iframeStore: true }, opts)
     console.log(opts.addressServer)
     const rootStoreAddress = await API.getRootStoreAddress(address.toLowerCase(), opts.addressServer)

--- a/src/3box.js
+++ b/src/3box.js
@@ -169,12 +169,12 @@ class Box {
    * @return    {Object}                            a json object with the profile for the given address
    */
   static async getProfile (address, opts = {}) {
-    const normalizedAddress = address.toLowerCase()
     opts = Object.assign({ useCacheService: true }, opts)
     let profile
     if (opts.useCacheService) {
-      profile = await API.getProfile(normalizedAddress, opts.profileServer)
+      profile = await API.getProfile(address, opts.profileServer)
     } else {
+      const normalizedAddress = address.toLowerCase()
       profile = await this._getProfileOrbit(normalizedAddress, opts)
     }
     return profile

--- a/src/__tests__/3box.test.js
+++ b/src/__tests__/3box.test.js
@@ -420,7 +420,8 @@ describe('3Box', () => {
       name: 'zfer',
       email: 'zfer@mail.com'
     })
-    expect(mockedUtils.fetchJson).toHaveBeenCalledWith('profile-server/profileList', { addressList: ['0x12345'] })
+    expect(mockedUtils.fetchJson)
+      .toHaveBeenCalledWith('profile-server/profileList', { addressList: ['0x12345'], didList: [] })
   })
 
   it('should be logged in', async () => {

--- a/src/__tests__/3box.test.js
+++ b/src/__tests__/3box.test.js
@@ -73,13 +73,16 @@ jest.mock('../space', () => {
   })
 })
 
+
 jest.mock('../utils/verifier')
 jest.mock('../utils/index', () => {
+  const actualUtils = jest.requireActual('../utils/index')
   const sha256 = require('js-sha256').sha256
   let addressMap = {}
   let linkmap = {}
   let linkNum = 0
   return {
+    isMuportDID: actualUtils.isMuportDID,
     openBoxConsent: jest.fn(async () => '0x8726348762348723487238476238746827364872634876234876234'),
     fetchJson: jest.fn(async (url, body) => {
       const split = url.split('/')

--- a/src/api.js
+++ b/src/api.js
@@ -7,9 +7,6 @@ const GRAPHQL_SERVER_URL = config.graphql_server_url
 const PROFILE_SERVER_URL = config.profile_server_url
 const ADDRESS_SERVER_URL = config.address_server_url
 
-const DID_MUPORT_PREFIX = 'did:muport:'
-const isMuportDID = (address) => address.startsWith(DID_MUPORT_PREFIX)
-
 async function getRootStoreAddress (identifier, serverUrl = ADDRESS_SERVER_URL) {
   // read orbitdb root store address from the 3box-address-server
   const res = await utils.fetchJson(serverUrl + '/odbAddress/' + identifier)
@@ -19,7 +16,7 @@ async function getRootStoreAddress (identifier, serverUrl = ADDRESS_SERVER_URL) 
 async function listSpaces (address, serverUrl = PROFILE_SERVER_URL) {
   try {
     // we await explicitly here to make sure the error is catch'd in the correct scope
-    if (isMuportDID(address)) {
+    if (utils.isMuportDID(address)) {
       return await utils.fetchJson(serverUrl + '/list-spaces?did=' + encodeURIComponent(address))
     } else {
       return await utils.fetchJson(serverUrl + '/list-spaces?address=' + encodeURIComponent(address))
@@ -32,7 +29,7 @@ async function listSpaces (address, serverUrl = PROFILE_SERVER_URL) {
 async function getSpace (address, name, serverUrl = PROFILE_SERVER_URL) {
   try {
     // we await explicitly here to make sure the error is catch'd in the correct scope
-    if (isMuportDID(address)) {
+    if (utils.isMuportDID(address)) {
       return await utils.fetchJson(serverUrl + `/space?did=${encodeURIComponent(address)}&name=${encodeURIComponent(name)}`)
     } else {
       return await utils.fetchJson(serverUrl + `/space?address=${encodeURIComponent(address)}&name=${encodeURIComponent(name)}`)
@@ -56,7 +53,7 @@ async function getThread (space, name, serverUrl = PROFILE_SERVER_URL) {
 async function getProfile (address, serverUrl = PROFILE_SERVER_URL) {
   try {
     // Note: we await explicitly to make sure the error is catch'd in the correct scope
-    if (isMuportDID(address)) {
+    if (utils.isMuportDID(address)) {
       const normalized = encodeURIComponent(address) // uppercase is significant in did:muport
       return await utils.fetchJson(serverUrl + '/profile?did=' + normalized)
     } else {

--- a/src/api.js
+++ b/src/api.js
@@ -67,7 +67,17 @@ async function getProfile (address, serverUrl = PROFILE_SERVER_URL) {
 
 async function getProfiles (addressArray, opts = {}) {
   opts = Object.assign({ profileServer: PROFILE_SERVER_URL }, opts)
-  const req = { addressList: addressArray }
+  const req = { addressList: [], didList: [] }
+
+  // Split addresses on ethereum / dids
+  addressArray.forEach(address => {
+    if (utils.isMuportDID(address)) {
+      req.didList.push(address)
+    } else {
+      req.addressList.push(address)
+    }
+  })
+
   const url = `${opts.profileServer}/profileList`
   return utils.fetchJson(url, req)
 }

--- a/src/api.js
+++ b/src/api.js
@@ -41,10 +41,19 @@ async function getThread (space, name, serverUrl = PROFILE_SERVER_URL) {
   })
 }
 
+const DID_MUPORT_PREFIX = 'did:muport:'
+const isMuportDID = (address) => address.startsWith(DID_MUPORT_PREFIX)
+
 async function getProfile (address, serverUrl = PROFILE_SERVER_URL) {
   try {
-    // we await explicitly here to make sure the error is catch'd in the correct scope
-    return await utils.fetchJson(serverUrl + '/profile?address=' + encodeURIComponent(address))
+    // Note: we await explicitly here to make sure the error is catch'd in the correct scope
+    if (isMuportDID(address)) {
+      const normalized = encodeURIComponent(address) // uppercase is significant in did:muport
+      return await utils.fetchJson(serverUrl + '/profile?did=' + normalized)
+    } else {
+      const normalized = encodeURIComponent(address.toLowerCase())
+      return await utils.fetchJson(serverUrl + '/profile?address=' + normalized)
+    }
   } catch (err) {
     return {} // empty profile
   }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,6 +2,8 @@ const fetch = typeof window !== 'undefined' ? window.fetch : require('node-fetch
 const Multihash = require('multihashes')
 const sha256 = require('js-sha256').sha256
 
+const DID_MUPORT_PREFIX = 'did:muport:'
+
 const HTTPError = (status, message) => {
   const e = new Error(message)
   e.statusCode = status
@@ -9,6 +11,8 @@ const HTTPError = (status, message) => {
 }
 
 module.exports = {
+  isMuportDID:  (address) => address.startsWith(DID_MUPORT_PREFIX),
+
   openBoxConsent: (fromAddress, ethereum) => {
     const text = 'This app wants to view and update your 3Box profile.'
     var msg = '0x' + Buffer.from(text, 'utf8').toString('hex')


### PR DESCRIPTION
- [x] getProfile
- [x] getProfiles
- [x] getSpace
- [x] listSpaces
- [x] throw an error locally when a did is used with the non cached version (not supported, see https://github.com/3box/3box-js/issues/226)