### PR TITLE
Update link profile logic

### DIFF
--- a/src/3box.js
+++ b/src/3box.js
@@ -382,26 +382,27 @@ class Box {
   }
 
   async _linkProfile () {
-    const address = this._3id.managementAddress
-    if (!localstorage.get('linkConsent_' + address)) {
+    let linkData = await this.public.get('ethereum_proof')
+
+    if (!linkData) {
+      const address = this._3id.managementAddress
       const did = this._3id.getDid()
-      let linkData = await this.public.get('ethereum_proof')
-      if (!linkData) {
-        const consent = await utils.getLinkConsent(address, did, this._web3provider)
-        linkData = {
-          consent_msg: consent.msg,
-          consent_signature: consent.sig,
-          linked_did: did
-        }
-        await this.public.set('ethereum_proof', linkData)
+
+      const consent = await utils.getLinkConsent(address, did, this._web3provider)
+
+      linkData = {
+        consent_msg: consent.msg,
+        consent_signature: consent.sig,
+        linked_did: did
       }
-      // Send consentSignature to 3box-address-server to link profile with ethereum address
-      try {
-        await utils.fetchJson(this._serverUrl + '/link', linkData)
-        localstorage.set('linkConsent_' + address, true)
-      } catch (err) {
-        console.error(err)
-      }
+      await this.public.set('ethereum_proof', linkData)
+    }
+
+    // Send consentSignature to 3box-address-server to link profile with ethereum address
+    try {
+      await utils.fetchJson(this._serverUrl + '/link', linkData)
+    } catch (err) {
+      console.error(err)
     }
   }
 

--- a/src/3box.js
+++ b/src/3box.js
@@ -133,7 +133,6 @@ class Box {
           const promises = syncPromises
           syncPromises = []
           await Promise.all(promises)
-          await this._ensureDIDPublished()
           this._onSyncDoneCB()
           // this._pubsub.unsubscribe(PINNING_ROOM)
         }
@@ -404,9 +403,8 @@ class Box {
     } catch (err) {
       console.error(err)
     }
-  }
 
-  async _ensureDIDPublished () {
+    // Ensure we self-published our did
     if (!(await this.public.get('proof_did'))) {
       // we can just sign an empty JWT as a proof that we own this DID
       await this.public.set('proof_did', await this._3id.signJWT())


### PR DESCRIPTION
- [ ] ~Move logic for linking profile into the 3id module~
- [x] Stop using localstorage, since the link is stored in the 3box anyway
- [x] Move the logic to happen during the same time as _ensureDIDPublished. There is no need to check it every time a new entry is added to the public profile.
