### PR TITLE
Hotfix v1.6.2: use the correct key for subscriptions.

### DIFF
--- a/src/__tests__/space.test.js
+++ b/src/__tests__/space.test.js
@@ -151,13 +151,13 @@ describe('Space', () => {
 
     it('subscribes to thread correctly', async () => {
       await space.subscribeThread('t1')
-      expect(await space.public.get('follow-thread-t1')).toEqual({ name: 't1' })
+      expect(await space.public.get('thread-t1')).toEqual({ name: 't1' })
       expect(await space.subscribedThreads()).toEqual(['t1'])
     })
 
     it('unsubscribes from thread correctly', async () => {
       await space.unsubscribeThread('t1')
-      expect(await space.public.get('follow-thread-t1')).toEqual()
+      expect(await space.public.get('thread-t1')).toEqual()
       expect(await space.subscribedThreads()).toEqual([])
     })
 

--- a/src/space.js
+++ b/src/space.js
@@ -76,7 +76,7 @@ class Space {
    * @param     {String}    name                    The name of the thread
    */
   async subscribeThread (name) {
-    const threadKey = `follow-thread-${name}`
+    const threadKey = `thread-${name}`
     await this._syncSpacePromise
     if (!(await this.public.get(threadKey))) {
       await this.public.set(threadKey, { name })
@@ -89,7 +89,7 @@ class Space {
    * @param     {String}    name                    The name of the thread
    */
   async unsubscribeThread (name) {
-    const threadKey = `follow-thread-${name}`
+    const threadKey = `thread-${name}`
     if (await this.public.get(threadKey)) {
       await this.public.remove(threadKey)
     }
@@ -103,7 +103,7 @@ class Space {
   async subscribedThreads () {
     const allEntries = await this.public.all()
     return Object.keys(allEntries).reduce((threads, key) => {
-      if (key.startsWith('follow-thread')) {
+      if (key.startsWith('thread')) {
         threads.push(allEntries[key].name)
       }
       return threads


### PR DESCRIPTION
The spec was not followed in how the threads where stored in the space key-value store.