### PR TITLE
fix: use seconds timestamps in metadata

### DIFF
--- a/src/__tests__/keyValueStore.test.js
+++ b/src/__tests__/keyValueStore.test.js
@@ -94,6 +94,7 @@ describe('KeyValueStore', () => {
       expect(v).toEqual('some-value')
       expect(m).toBeDefined()
       expect(m.timestamp).toBeDefined()
+      expect('' + m.timestamp).toHaveLength(10) // this will break around year 2286
     })
 
     it('should return an undefined value for unknown key', async () => {

--- a/src/keyValueStore.js
+++ b/src/keyValueStore.js
@@ -28,7 +28,15 @@ class KeyValueStore {
    */
   async getMetadata (key) {
     const x = await this._get(key)
-    return x ? { timestamp: x.timeStamp } : x
+
+    if (!x) {
+      return x
+    }
+
+    // ms -> seconds, see issue #396 for details
+    const timestamp = Math.floor(x.timeStamp / 1000)
+
+    return { timestamp }
   }
 
   /**


### PR DESCRIPTION
Fix #396 