### PR TITLE
fix(spaces): Throw error if key is not defined

### DIFF
--- a/src/__tests__/keyValueStore.test.js
+++ b/src/__tests__/keyValueStore.test.js
@@ -67,6 +67,11 @@ describe('KeyValueStore', () => {
     expect(ensureConnected).toHaveBeenCalledTimes(2)
   })
 
+  it('should throw if key not given', async () => {
+    expect(keyValueStore.set()).rejects.toEqual(new Error('key is a required argument'))
+    expect(keyValueStore.remove()).rejects.toEqual(new Error('key is a required argument'))
+  })
+
   it('should sync an old profile correctly', async () => {
     let ipfs2 = await utils.initIPFS(3)
     let orbitdb2 = new OrbitDB(ipfs2, './tmp/orbitdb2')

--- a/src/__tests__/privateStore.test.js
+++ b/src/__tests__/privateStore.test.js
@@ -106,6 +106,11 @@ describe('PrivateStore', () => {
     expect(await privateStore.get('key2')).toBeNull()
   })
 
+  it('should throw if key not given', async () => {
+    expect(privateStore.set()).rejects.toEqual(new Error('Entry to encrypt cannot be undefined'))
+    expect(privateStore.remove()).rejects.toEqual(new Error('key is a required argument'))
+  })
+
   describe('log', () => {
 
     beforeEach(async () => {

--- a/src/__tests__/publicStore.test.js
+++ b/src/__tests__/publicStore.test.js
@@ -25,6 +25,11 @@ describe('PublicStore', () => {
     expect(linkProfile).toHaveBeenCalledWith()
   })
 
+  it('should throw if key not given', async () => {
+    expect(publicStore.set()).rejects.toEqual(new Error('key is a required argument'))
+    expect(publicStore.remove()).rejects.toEqual(new Error('key is a required argument'))
+  })
+
   it('should return profile correctly', async () => {
     expect(await publicStore.all()).toEqual({ key1: 'value1' })
   })

--- a/src/__tests__/space.test.js
+++ b/src/__tests__/space.test.js
@@ -113,6 +113,11 @@ describe('Space', () => {
         k3: 'v3'
       })
     })
+
+    it('should throw if key not given', async () => {
+      expect(space.public.set()).rejects.toEqual(new Error('key is a required argument'))
+      expect(space.public.remove()).rejects.toEqual(new Error('key is a required argument'))
+    })
   })
 
   describe('private store reducer', () => {
@@ -141,6 +146,11 @@ describe('Space', () => {
         k1: 'sv1',
         k3: 'sv3'
       })
+    })
+
+    it('should throw if key not given', async () => {
+      expect(space.private.set()).rejects.toEqual(new Error('key is a required argument'))
+      expect(space.private.remove()).rejects.toEqual(new Error('key is a required argument'))
     })
   })
 

--- a/src/keyValueStore.js
+++ b/src/keyValueStore.js
@@ -1,3 +1,5 @@
+const { throwIfUndefined } = require('./utils/index')
+
 class KeyValueStore {
   /**
    * Please use **box.public** or **box.private** to get the instance of this class
@@ -47,6 +49,7 @@ class KeyValueStore {
    * @return    {Boolean}                           true if successful
    */
   async set (key, value) {
+    throwIfUndefined(key, 'key')
     this._requireLoad()
     this._ensureConnected()
     const timeStamp = new Date().getTime()
@@ -61,6 +64,7 @@ class KeyValueStore {
    * @return    {Boolean}                           true if successful
    */
   async remove (key) {
+    throwIfUndefined(key, 'key')
     this._requireLoad()
     this._ensureConnected()
     await this._db.del(key)

--- a/src/privateStore.js
+++ b/src/privateStore.js
@@ -51,6 +51,7 @@ class PrivateStore extends KeyValueStore {
   }
 
   _genDbKey (key) {
+    utils.throwIfUndefined(key, 'key')
     return utils.sha256Multihash(this._salt + key)
   }
 

--- a/src/publicStore.js
+++ b/src/publicStore.js
@@ -1,4 +1,5 @@
 const KeyValueStore = require('./keyValueStore')
+const { throwIfUndefined } = require('./utils/index')
 
 class ProfileStore extends KeyValueStore {
   constructor (orbitdb, name, linkProfile, ensureConnected, _3id) {
@@ -7,6 +8,7 @@ class ProfileStore extends KeyValueStore {
   }
 
   async set (key, value) {
+    throwIfUndefined(key, 'key')
     this._linkProfile()
     return super.set(key, value)
   }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -113,6 +113,12 @@ module.exports = {
     }
   },
 
+  throwIfUndefined: (arg, name) => {
+    if (arg === undefined || arg === null) {
+      throw new Error(`${name} is a required argument`)
+    }
+  },
+
   sha256Multihash: str => {
     const digest = Buffer.from(sha256.digest(str))
     return Multihash.encode(digest, 'sha2-256').toString('hex')


### PR DESCRIPTION
Fixes #401 

This PR adds a check to all `set` and `remove` methods that throws an error if `key` is not defined.