### PR TITLE
fix(3id): Use orbit-db-keystore to import private key in correct format

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "did-jwt": "^0.1.1",
-    "elliptic": "^6.4.1",
     "ethers": "^4.0.20",
     "graphql-request": "^1.8.2",
     "https-did-resolver": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "./node_modules/.bin/standard --verbose src/**",
-    "test": "rm -rf ./tmp ; jest --forceExit --coverage --runInBand --testURL=\"http://localhost\"",
+    "test": "rm -rf ./tmp ; jest --detectOpenHandles --coverage --runInBand --testURL=\"http://localhost\"",
     "build:es5": "rm -rf ./lib; ./node_modules/.bin/babel src --out-dir lib --ignore=src/__tests__/,src/__mocks__/",
     "build:dist": "./node_modules/.bin/webpack --config webpack.config.js --mode=development",
     "build:dist:dev": "./node_modules/.bin/webpack --config webpack.dev.config.js --mode=development",

--- a/src/3box.js
+++ b/src/3box.js
@@ -82,7 +82,8 @@ class Box {
     this._orbitdb = new OrbitDB(this._ipfs, opts.orbitPath) // , { cache })
     globalOrbitDB = this._orbitdb
 
-    const key = this._3id.getKeyringBySpaceName(rootStoreName).getDBKey()
+    const dbKey = this._3id.getKeyringBySpaceName(rootStoreName).getDBKey()
+    const key = await this._orbitdb.keystore.importPrivateKey(dbKey)
     this._rootStore = await this._orbitdb.feed(rootStoreName, {
       key,
       write: [key.getPublic('hex')]

--- a/src/3id/__tests__/keyring.test.js
+++ b/src/3id/__tests__/keyring.test.js
@@ -42,7 +42,7 @@ describe('Keyring', () => {
 
   it('getDBKey works correctly', async () => {
     const key = keyring1.getDBKey()
-    expect(key.getPublic('hex')).toEqual('048aaa695fa16f2a2279e1de718d80e00f4f4ddf30fe8674bbdb9e1f11778c2f77f8ffb5ad2bd3f1f9840b3462c26f756ec0f47626894c20ed247145f5c0e26fe8')
+    expect(key).toEqual('68957df606e586990a6286239987aaf4c902971ae642d50609d35ff36fb0728a')
   })
 
   it('signs data correctly', async () => {

--- a/src/3id/keyring.js
+++ b/src/3id/keyring.js
@@ -1,8 +1,6 @@
 const { HDNode } = require('ethers').utils
 const nacl = require('tweetnacl')
 nacl.util = require('tweetnacl-util')
-const EC = require('elliptic').ec
-const ec = new EC('secp256k1')
 const SimpleSigner = require('did-jwt').SimpleSigner
 const { sha256 } = require('../utils/index')
 
@@ -60,7 +58,7 @@ class Keyring {
   }
 
   getDBKey () {
-    return ec.keyFromPrivate(this.signingKey.privateKey.slice(2))
+    return this.signingKey.privateKey.slice(2)
   }
 
   getDBSalt () {

--- a/src/__tests__/keyValueStore.test.js
+++ b/src/__tests__/keyValueStore.test.js
@@ -8,7 +8,7 @@ const STORE_NAME = '09ab7cd93f9e.public'
 
 const THREEID_MOCK = {
   getKeyringBySpaceName: () => {
-    return { getDBKey: () => ec.keyFromPrivate('f917ac6883f88798a8ce39821fa523f2acd17c0ba80c724f219367e76d8f2c46') }
+    return { getDBKey: () => 'f917ac6883f88798a8ce39821fa523f2acd17c0ba80c724f219367e76d8f2c46' }
   }
 }
 
@@ -86,7 +86,7 @@ describe('KeyValueStore', () => {
     expect(await keyValueStore2.get('key2')).toBeUndefined()
     expect(await keyValueStore2.get('key3')).toBeUndefined()
     await orbitdb2.stop()
-    // await ipfs2.stop()
+    await utils.stopIPFS(ipfs2, 3)
   })
 
   describe('metdata', () => {
@@ -155,8 +155,11 @@ describe('KeyValueStore', () => {
     })
   })
 
-  // afterAll(async () => {
-  //   await orbitdb.stop()
-  //   await ipfs.stop()
-  // })
+  it('should including ALL entries, including DEL ops', async () => {
+  })
+
+  afterAll(async () => {
+    await orbitdb.stop()
+    await utils.stopIPFS(ipfs, 2)
+  })
 })

--- a/src/__tests__/testUtils.js
+++ b/src/__tests__/testUtils.js
@@ -1,4 +1,5 @@
 const IPFS = require('ipfs')
+const fs = require('fs')
 
 const CONF_1 = {
   EXPERIMENTAL: {
@@ -116,5 +117,11 @@ module.exports = {
       ipfs.on('error', reject)
       ipfs.on('ready', () => resolve(ipfs))
     })
+  },
+  stopIPFS: async (ipfs, useAltConf) => {
+    // seems to be an issue with the api file not being present when trying to close ipfs
+    const apiFilePath = CONFS[useAltConf].repo + 'api'
+    fs.closeSync(fs.openSync(apiFilePath, 'w'))
+    await ipfs.stop()
   }
 }

--- a/src/__tests__/thread.test.js
+++ b/src/__tests__/thread.test.js
@@ -14,13 +14,13 @@ const MSG4 = 'message4'
 
 const THREEID1_MOCK = {
   _mainKeyring: {
-    getDBKey: () => ec.keyFromPrivate('f917ac6883f88798a8ce39821fa523f2acd17c0ba80c724f219367e76d8f2c46')
+    getDBKey: () => 'f917ac6883f88798a8ce39821fa523f2acd17c0ba80c724f219367e76d8f2c46'
   },
   getDid: () => 'did:3:mydid1'
 }
 const THREEID2_MOCK = {
   _mainKeyring: {
-    getDBKey: () => ec.keyFromPrivate('f977777aaaaaaabbbbbbb9821fa523f2acd17c0ba80c724f219367e76d8f2c46')
+    getDBKey: () => 'f977777aaaaaaabbbbbbb9821fa523f2acd17c0ba80c724f219367e76d8f2c46'
   },
   getDid: () => 'did:3:mydid2'
 }
@@ -147,5 +147,15 @@ describe('Thread', () => {
       expect(posts1[1].message).toEqual(MSG2)
       expect(posts1[1].postId).toEqual(posts2[1].postId)
     })
+
+    afterAll(async () => {
+      await orbitdb2.stop()
+      await utils.stopIPFS(ipfs2, 5)
+    })
+  })
+
+  afterAll(async () => {
+    await orbitdb.stop()
+    await utils.stopIPFS(ipfs, 4)
   })
 })

--- a/src/keyValueStore.js
+++ b/src/keyValueStore.js
@@ -117,7 +117,8 @@ class KeyValueStore {
   }
 
   async _load (odbAddress) {
-    const key = this._3id.getKeyringBySpaceName(this._name).getDBKey()
+    const dbKey = this._3id.getKeyringBySpaceName(this._name).getDBKey()
+    const key = await this._orbitdb.keystore.importPrivateKey(dbKey)
     this._db = await this._orbitdb.keyvalue(odbAddress || this._name, {
       key,
       write: [key.getPublic('hex')]

--- a/src/thread.js
+++ b/src/thread.js
@@ -83,7 +83,8 @@ class Thread {
 
   async _load (odbAddress) {
     // TODO - threads should use the space keyring once pairwise DIDs are implemented
-    const key = this._3id._mainKeyring.getDBKey()
+    const dbKey = this._3id._mainKeyring.getDBKey()
+    const key = await this._orbitdb.keystore.importPrivateKey(dbKey)
     this._db = await this._orbitdb.log(odbAddress || this._name, {
       key,
       write: ['*']


### PR DESCRIPTION
Sometimes we get a different version of elliptic than orbit-db-keystore which causes issues since it thinks that a ec key instance is some other object. This PR fixes this by using orbit-db-keystore directly.