### PR TITLE
Broken dep. (@babel/runtime v.s. babel-runtime)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "homepage": "https://github.com/uport-project/3box-js#readme",
   "dependencies": {
     "@babel/runtime": "^7.1.2",
+    "babel-runtime": "^6.26.0",
     "did-jwt": "^0.1.1",
     "ethers": "^4.0.20",
     "graphql-request": "^1.8.2",


### PR DESCRIPTION
Before...
```
ERROR in ./node_modules/muport-did-resolver/lib/register.js
Module not found: Error: Can't resolve 'babel-runtime/helpers/asyncToGenerator' in 'C:\Users\kuhnc\Developer\kudosDisplay\node_modules\muport-did-resolver\lib'
 @ ./node_modules/muport-did-resolver/lib/register.js 7:25-74
 @ ./node_modules/3box/lib/utils/verifier.js
 @ ./node_modules/3box/lib/api.js
 @ ./node_modules/3box/lib/3box.js
 @ ./src/dapp.ts
...
```
After `npm i babel-runtime`
```

Child html-webpack-plugin for "index.html":
     1 asset
    Entrypoint undefined = index.html
    [0] ./node_modules/html-webpack-plugin/lib/loader.js!./src/index.html 6.17 KiB {1} [built]
    [1] ./node_modules/lodash/lodash.js 527 KiB {1} [built]
    [2] (webpack)/buildin/global.js 472 bytes {1} [built]
    [3] (webpack)/buildin/module.js 497 bytes {1} [built]
i ｢wdm｣: Compiled successfully.
```