### PR TITLE
feat(api): add blocklist to getProfile and getSpace

### DIFF
--- a/src/3box.js
+++ b/src/3box.js
@@ -179,6 +179,8 @@ class Box {
    *
    * @param     {String}    address                 An ethereum address
    * @param     {Object}    opts                    Optional parameters
+   * @param     {Function}  opts.blocklist          A function that takes an address and returns true if the user has been blocked
+   * @param     {String}    opts.metadata           flag to retrieve metadata
    * @param     {String}    opts.addressServer      URL of the Address Server
    * @param     {Object}    opts.ipfs               A js-ipfs ipfs object
    * @param     {Boolean}   opts.useCacheService    Use 3Box API and Cache Service to fetch profile instead of OrbitDB. Default true.
@@ -221,8 +223,9 @@ class Box {
    * @param     {String}    address                 An ethereum address
    * @param     {String}    name                    A space name
    * @param     {Object}    opts                    Optional parameters
-   * @param     {String}    opts.profileServer      URL of Profile API server
+   * @param     {Function}  opts.blocklist          A function that takes an address and returns true if the user has been blocked
    * @param     {String}    opts.metadata           flag to retrieve metadata
+   * @param     {String}    opts.profileServer      URL of Profile API server
    * @return    {Object}                            a json object with the public space data
    */
   static async getSpace (address, name, opts = {}) {

--- a/src/api.js
+++ b/src/api.js
@@ -27,7 +27,8 @@ async function listSpaces (address, serverUrl = PROFILE_SERVER_URL) {
   }
 }
 
-async function getSpace (address, name, serverUrl = PROFILE_SERVER_URL, { metadata } = {}) {
+async function getSpace (address, name, serverUrl = PROFILE_SERVER_URL, { metadata, blocklist } = {}) {
+  if (blocklist && blocklist(address)) throw new Error(`user with ${address} is blocked`)
   let url = `${serverUrl}/space`
 
   try {
@@ -65,7 +66,8 @@ async function getThread (space, name, serverUrl = PROFILE_SERVER_URL) {
   })
 }
 
-async function getProfile (address, serverUrl = PROFILE_SERVER_URL, { metadata } = {}) {
+async function getProfile (address, serverUrl = PROFILE_SERVER_URL, { metadata, blocklist } = {}) {
+  if (blocklist && blocklist(address)) throw new Error(`user with ${address} is blocked`)
   let url = `${serverUrl}/profile`
 
   try {


### PR DESCRIPTION
This PR adds a simple blocklist function that can be passed to `getProfile` and `getSpace`. This function accepts an address and should return a boolean. If true the `get` functions will throw an error saying the user is blocked.