### PR TITLE
ref: api changes, joinThreadByAddress, keep active threads by address

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,9 @@ idUtils.verifyClaim(claim)
         * [.getProfile(address, opts)](#Box.getProfile) ⇒ <code>Object</code>
         * [.getProfiles(address, opts)](#Box.getProfiles) ⇒ <code>Object</code>
         * [.getSpace(address, name, opts)](#Box.getSpace) ⇒ <code>Object</code>
-        * [.getThread(space, name, opts)](#Box.getThread) ⇒ <code>Array.&lt;Object&gt;</code>
+        * [.getThread(space, name, firstModerator, members, opts)](#Box.getThread) ⇒ <code>Array.&lt;Object&gt;</code>
+        * [.getThreadByAddress(address, opts)](#Box.getThreadByAddress) ⇒ <code>Array.&lt;Object&gt;</code>
+        * [.getConfig(address, opts)](#Box.getConfig) ⇒ <code>Array.&lt;Object&gt;</code>
         * [.listSpaces(address, opts)](#Box.listSpaces) ⇒ <code>Object</code>
         * [.profileGraphQL(query, opts)](#Box.profileGraphQL) ⇒ <code>Object</code>
         * [.getVerifiedAccounts(profile)](#Box.getVerifiedAccounts) ⇒ <code>Object</code>
@@ -464,7 +466,7 @@ Get the public data in a space of a given address with the given name
 
 <a name="Box.getThread"></a>
 
-#### Box.getThread(space, name, opts) ⇒ <code>Array.&lt;Object&gt;</code>
+#### Box.getThread(space, name, firstModerator, members, opts) ⇒ <code>Array.&lt;Object&gt;</code>
 Get all posts that are made to a thread.
 
 **Kind**: static method of [<code>Box</code>](#Box)  
@@ -474,6 +476,36 @@ Get all posts that are made to a thread.
 | --- | --- | --- |
 | space | <code>String</code> | The name of the space the thread is in |
 | name | <code>String</code> | The name of the thread |
+| firstModerator | <code>String</code> | The DID (or ethereum address) of the first moderator |
+| members | <code>Boolean</code> | True if only members are allowed to post |
+| opts | <code>Object</code> | Optional parameters |
+| opts.profileServer | <code>String</code> | URL of Profile API server |
+
+<a name="Box.getThreadByAddress"></a>
+
+#### Box.getThreadByAddress(address, opts) ⇒ <code>Array.&lt;Object&gt;</code>
+Get all posts that are made to a thread.
+
+**Kind**: static method of [<code>Box</code>](#Box)  
+**Returns**: <code>Array.&lt;Object&gt;</code> - An array of posts  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| address | <code>String</code> | The orbitdb-address of the thread |
+| opts | <code>Object</code> | Optional parameters |
+| opts.profileServer | <code>String</code> | URL of Profile API server |
+
+<a name="Box.getConfig"></a>
+
+#### Box.getConfig(address, opts) ⇒ <code>Array.&lt;Object&gt;</code>
+Get the configuration of a users 3Box
+
+**Kind**: static method of [<code>Box</code>](#Box)  
+**Returns**: <code>Array.&lt;Object&gt;</code> - An array of posts  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| address | <code>String</code> | The ethereum address |
 | opts | <code>Object</code> | Optional parameters |
 | opts.profileServer | <code>String</code> | URL of Profile API server |
 
@@ -668,7 +700,9 @@ Get all values and optionally metadata
     * [new Space()](#new_Space_new)
     * [.public](#Space+public)
     * [.private](#Space+private)
+    * [.DID](#Space+DID)
     * [.joinThread(name, opts)](#Space+joinThread) ⇒ [<code>Thread</code>](#Thread)
+    * [.joinThreadByAddress(address, opts)](#Space+joinThreadByAddress) ⇒ [<code>Thread</code>](#Thread)
     * [.subscribeThread(address, config)](#Space+subscribeThread)
     * [.unsubscribeThread(address)](#Space+unsubscribeThread)
     * [.subscribedThreads()](#Space+subscribedThreads) ⇒ <code>Array.&lt;Objects&gt;</code>
@@ -698,6 +732,16 @@ Please use **box.openSpace** to get the instance of this class
 | --- | --- | --- |
 | private | [<code>KeyValueStore</code>](#KeyValueStore) | access the private store of the space |
 
+<a name="Space+DID"></a>
+
+#### space.DID
+**Kind**: instance property of [<code>Space</code>](#Space)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| DID | <code>String</code> | the did of the user in this space |
+
 <a name="Space+joinThread"></a>
 
 #### space.joinThread(name, opts) ⇒ [<code>Thread</code>](#Thread)
@@ -708,10 +752,24 @@ Join a thread. Use this to start receiving updates from, and to post in threads
 
 | Param | Type | Description |
 | --- | --- | --- |
-| name | <code>String</code> | The name or full address of the thread |
+| name | <code>String</code> | The name of the thread |
 | opts | <code>Object</code> | Optional parameters |
-| opts.membersOnly | <code>Boolean</code> | join a members only thread, which only members can post in, ignores if joined by address |
-| opts.rootMod | <code>String</code> | the rootMod, known as first moderator of a thread, by default user is moderator, ignored if joined by address |
+| opts.firstModerator | <code>String</code> | DID of first moderator of a thread, by default, user is first moderator |
+| opts.members | <code>Boolean</code> | join a members only thread, which only members can post in, defaults to open thread |
+| opts.noAutoSub | <code>Boolean</code> | Disable auto subscription to the thread when posting to it (default false) |
+
+<a name="Space+joinThreadByAddress"></a>
+
+#### space.joinThreadByAddress(address, opts) ⇒ [<code>Thread</code>](#Thread)
+Join a thread by full thread address. Use this to start receiving updates from, and to post in threads
+
+**Kind**: instance method of [<code>Space</code>](#Space)  
+**Returns**: [<code>Thread</code>](#Thread) - An instance of the thread class for the joined thread  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| address | <code>String</code> | The full address of the thread |
+| opts | <code>Object</code> | Optional parameters |
 | opts.noAutoSub | <code>Boolean</code> | Disable auto subscription to the thread when posting to it (default false) |
 
 <a name="Space+subscribeThread"></a>
@@ -726,7 +784,7 @@ Subscribe to the given thread, if not already subscribed
 | address | <code>String</code> | The address of the thread |
 | config | <code>Object</code> | configuration and thread meta data |
 | opts.name | <code>String</code> | Name of thread |
-| opts.rootMod | <code>String</code> | DID of the root moderator |
+| opts.firstModerator | <code>String</code> | DID of the first moderator |
 | opts.members | <code>String</code> | Boolean string, true if a members only thread |
 
 <a name="Space+unsubscribeThread"></a>
@@ -746,7 +804,7 @@ Unsubscribe from the given thread, if subscribed
 Get a list of all the threads subscribed to in this space
 
 **Kind**: instance method of [<code>Space</code>](#Space)  
-**Returns**: <code>Array.&lt;Objects&gt;</code> - A list of thread objects as { address, rootMod, members, name}  
+**Returns**: <code>Array.&lt;Objects&gt;</code> - A list of thread objects as { address, firstModerator, members, name}  
 <a name="Thread"></a>
 
 ### Thread

--- a/example/index.html
+++ b/example/index.html
@@ -80,9 +80,9 @@
 
           <h3> Threads: </h3>
           <input type="text" id="threadName" placeholder="Name or Address"></br>
-          <input type="text" id="threadRootMod" placeholder="Thread Root Moderator"></br>
+          <input type="text" id="threadfirstModerator" placeholder="Thread Root Moderator"></br>
             <span > Members Only Thread </span>
-          <input type="radio" name="membersOnly" id='membersOnly' value="true"> </br>
+          <input type="radio" name="members" id='members' value="true"> </br>
           <button id="joinThread" type="button" class="btn btn btn-primary" >Join thread</button>  </br></br>
 
           <div id="threadModeration" style="display: none;">

--- a/example/index.js
+++ b/example/index.js
@@ -94,11 +94,11 @@ bopen.addEventListener('click', event => {
       joinThread.addEventListener('click', () => {
         const name = threadName.value
         const firstModerator = threadfirstModerator.value
-        const members = members.checked
+        const membersBool = members.checked
         posts.style.display = 'block'
         threadModeration.style.display = 'block'
         if (members.checked) threadMembers.style.display = 'block'
-        box.spaces[window.currentSpace].joinThread(name, {firstModerator, members}).then(thread => {
+        box.spaces[window.currentSpace].joinThread(name, {firstModerator, members: membersBool}).then(thread => {
           window.currentThread = thread
           thread.onNewPost(post => {
             updateThreadData()

--- a/example/index.js
+++ b/example/index.js
@@ -93,12 +93,12 @@ bopen.addEventListener('click', event => {
 
       joinThread.addEventListener('click', () => {
         const name = threadName.value
-        const rootMod = threadRootMod.value
-        const members = membersOnly.checked
+        const firstModerator = threadfirstModerator.value
+        const members = members.checked
         posts.style.display = 'block'
         threadModeration.style.display = 'block'
-        if (membersOnly.checked) threadMembers.style.display = 'block'
-        box.spaces[window.currentSpace].joinThread(name, {rootMod, membersOnly: members}).then(thread => {
+        if (members.checked) threadMembers.style.display = 'block'
+        box.spaces[window.currentSpace].joinThread(name, {firstModerator, members}).then(thread => {
           window.currentThread = thread
           thread.onNewPost(post => {
             updateThreadData()
@@ -148,7 +148,7 @@ bopen.addEventListener('click', event => {
 
       const updateThreadCapabilities = () => {
         threadMemberList.innerHTML = ''
-        if (window.currentThread._membersOnly) {
+        if (window.currentThread._members) {
           window.currentThread.listMembers().then(members => {
             members.map(member => {
                 threadMemberList.innerHTML += member + '<br />'

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/3box/3box-js#readme",
   "dependencies": {
-    "3box-orbitdb-plugins": "^1.0.3",
+    "3box-orbitdb-plugins": "^1.0.4",
     "3id-resolver": "^0.0.5",
     "@babel/runtime": "^7.4.5",
     "did-jwt": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/3box/3box-js#readme",
   "dependencies": {
-    "3box-orbitdb-plugins": "^1.0.4",
+    "3box-orbitdb-plugins": "^1.0.5",
     "3id-resolver": "^0.0.5",
     "@babel/runtime": "^7.4.5",
     "did-jwt": "^0.1.3",

--- a/src/3box.js
+++ b/src/3box.js
@@ -242,14 +242,14 @@ class Box {
    *
    * @param     {String}    space                   The name of the space the thread is in
    * @param     {String}    name                    The name of the thread
-   * @param     {String}    rootMod                 The DID (or ethereum address) of the root moderator
-   * @param     {Boolean}   membersOnly             True if only members are allowed to post
+   * @param     {String}    firstModerator          The DID (or ethereum address) of the first moderator
+   * @param     {Boolean}   members                 True if only members are allowed to post
    * @param     {Object}    opts                    Optional parameters
    * @param     {String}    opts.profileServer      URL of Profile API server
    * @return    {Array<Object>}                     An array of posts
    */
-  static async getThread (space, name, rootMod, membersOnly, opts = {}) {
-    return API.getThread(space, name, rootMod, membersOnly, opts)
+  static async getThread (space, name, firstModerator, members, opts = {}) {
+    return API.getThread(space, name, firstModerator, members, opts)
   }
 
   /**

--- a/src/__mocks__/3ID.js
+++ b/src/__mocks__/3ID.js
@@ -1,0 +1,60 @@
+const didJWT = require('did-jwt')
+const Identities = require('orbit-db-identity-provider')
+const { OdbIdentityProvider } = require('3box-orbitdb-plugins')
+Identities.addIdentityProvider(OdbIdentityProvider)
+
+const pubKey = '044f5c08e2150b618264c4794d99a22238bf60f1133a7f563e74fcf55ddb16748159872687a613545c65567d2b7a4d4e3ac03763e1d9a5fcfe512a371faa48a781'
+const privKey = '95838ece1ac686bde68823b21ce9f564bc536eebb9c3500fa6da81f17086a6be'
+
+const didResolverMock = async (did) => {
+  return {
+    '@context': 'https://w3id.org/did/v1',
+    'id': did,
+    'publicKey': [{
+      'id': `${did}#signingKey`,
+      'type': 'Secp256k1VerificationKey2018',
+      'publicKeyHex': pubKey
+    }],
+    'authentication': [{
+      'type': 'Secp256k1SignatureAuthentication2018',
+      'publicKey': `${did}#signingKey`
+    }]
+  }
+}
+
+const threeIDMockFactory = (did) => {
+  const signJWT = payload => {
+    return didJWT.createJWT(payload, {
+      signer: didJWT.SimpleSigner(privKey),
+      issuer: did
+    })
+  }
+
+  const getKeyringBySpaceName = () => {
+    return {
+      getPublicKeys: () => {
+        return { signingKey: pubKey }
+      }
+    }
+  }
+
+  const getSubDID = () => did
+
+  const getOdbId = () => {
+    return Identities.createIdentity({
+      type: '3ID',
+      threeId: {signJWT, getKeyringBySpaceName, DID: did, getSubDID},
+      identityKeysPath: `./tmp/${did}`
+    })
+  }
+
+  return {
+    DID: did,
+    signJWT,
+    getKeyringBySpaceName,
+    getOdbId,
+    getSubDID
+  }
+}
+
+module.exports = { threeIDMockFactory, didResolverMock }

--- a/src/__tests__/__snapshots__/3box.test.js.snap
+++ b/src/__tests__/__snapshots__/3box.test.js.snap
@@ -4,7 +4,7 @@ exports[`3Box should handle a second address/account correctly 1`] = `"/orbitdb/
 
 exports[`3Box should handle a second address/account correctly 2`] = `"/orbitdb/QmUhJvnFShu3mEiKNbHFs2hk13eWtY9K8RGiLdtacqBgD6/ab8c73d8f.root"`;
 
-exports[`3Box should handle error and not link profile on first call to _linkProfile 1`] = `"did:3:asdfasdf"`;
+exports[`3Box should handle error and not link profile on first call to _linkProfile 1`] = `"did:3:zdpuAsaK9YsqpphSBeQvfrKAjs8kF7vUX4Y3kMkMRgEQigzCt"`;
 
 exports[`3Box should openBox correctly 1`] = `"/orbitdb/QmSyGQBefvwYG9Zb9Pro1ckvboWnTmHT2teVrfMerzoSKZ/b932fe7ab.root"`;
 

--- a/src/__tests__/keyValueStore.test.js
+++ b/src/__tests__/keyValueStore.test.js
@@ -6,45 +6,16 @@ const Identities = require('orbit-db-identity-provider')
 Identities.addIdentityProvider(OdbIdentityProvider)
 const AccessControllers = require('orbit-db-access-controllers')
 AccessControllers.addAccessController({ AccessController: LegacyIPFS3BoxAccessController })
-const didJWT = require('did-jwt')
 const { registerMethod } = require('did-resolver')
+const { threeIDMockFactory, didResolverMock } = require('../__mocks__/3ID')
 
 const STORE_NAME = '09ab7cd93f9e.public'
+const DID1 = 'did:3:zdpuAsaK9YsqpphSBeQvfrKAjs8kF7vUX4Y3kMkMRgEQigzCt'
+const THREEID_MOCK = threeIDMockFactory(DID1)
 
-const THREEID_MOCK = {
-  DID: 'did:3:asdfasdf',
-  getKeyringBySpaceName: () => {
-    return {
-      getPublicKeys: () => {
-        return { signingKey: '044f5c08e2150b618264c4794d99a22238bf60f1133a7f563e74fcf55ddb16748159872687a613545c65567d2b7a4d4e3ac03763e1d9a5fcfe512a371faa48a781' }
-      }
-    }
-  },
-  signJWT: payload => {
-    return didJWT.createJWT(payload, {
-      signer: didJWT.SimpleSigner('95838ece1ac686bde68823b21ce9f564bc536eebb9c3500fa6da81f17086a6be'),
-      issuer: 'did:3:asdfasdf'
-    })
-  }
-}
-registerMethod('3', async () => {
-  return {
-    '@context': 'https://w3id.org/did/v1',
-    'id': 'did:3:asdfasdf',
-    'publicKey': [{
-      'id': 'did:3:asdfasdf#signingKey',
-      'type': 'Secp256k1VerificationKey2018',
-      'publicKeyHex': '044f5c08e2150b618264c4794d99a22238bf60f1133a7f563e74fcf55ddb16748159872687a613545c65567d2b7a4d4e3ac03763e1d9a5fcfe512a371faa48a781'
-    }],
-    'authentication': [{
-      'type': 'Secp256k1SignatureAuthentication2018',
-      'publicKey': 'did:2:asdfasdf#signingKey'
-    }]
-  }
-})
+registerMethod('3', didResolverMock)
 
 const ensureConnected = jest.fn()
-
 
 describe('KeyValueStore', () => {
   let ipfs

--- a/src/__tests__/space.test.js
+++ b/src/__tests__/space.test.js
@@ -255,7 +255,7 @@ describe('Space', () => {
 
     it('a thread loaded by address, must be in same space as threadname, otherwise throws', async () => {
       const threadAddress = "/orbitdb/zdpuAz8c2gjonfuhYCfPJqZJUfYM5Kd7bpHaMyJZSLDMHSNvQ/3box.thread.errorspace.test"
-      await expect(space.joinThread(threadAddress)).rejects.toThrow(/must open within same space/)
+      await expect(space.joinThreadByAddress(threadAddress)).rejects.toThrow(/must open within same space/)
     })
 
     it('joins thread correctly, no auto subscription', async () => {

--- a/src/api.js
+++ b/src/api.js
@@ -55,17 +55,17 @@ async function getSpace (address, name, serverUrl = PROFILE_SERVER_URL, { metada
   }
 }
 
-async function getThread (space, name, rootMod, membersOnly, opts = {}) {
+async function getThread (space, name, firstModerator, members, opts = {}) {
   const serverUrl = opts.profileServer || PROFILE_SERVER_URL
-  if (rootMod.startsWith('0x')) {
-    const conf = await getConfig(rootMod, opts)
-    if (!conf.spaces[space] || !conf.spaces[space].DID) throw new Error(`Could not find appropriate DID for address ${rootMod}`)
-    rootMod = conf.spaces[space].DID
+  if (firstModerator.startsWith('0x')) {
+    const conf = await getConfig(firstModerator, opts)
+    if (!conf.spaces[space] || !conf.spaces[space].DID) throw new Error(`Could not find appropriate DID for address ${firstModerator}`)
+    firstModerator = conf.spaces[space].DID
   }
   return new Promise(async (resolve, reject) => {
     try {
       let url = `${serverUrl}/thread?space=${encodeURIComponent(space)}&name=${encodeURIComponent(name)}`
-      url += `&mod=${encodeURIComponent(rootMod)}&members=${encodeURIComponent(membersOnly)}`
+      url += `&mod=${encodeURIComponent(firstModerator)}&members=${encodeURIComponent(members)}`
       const res = await utils.fetchJson(url)
       resolve(res)
     } catch (err) {

--- a/src/space.js
+++ b/src/space.js
@@ -76,7 +76,7 @@ class Space {
    */
   async joinThread (name, opts = {}) {
     const subscribeFn = opts.noAutoSub ? () => {} : this.subscribeThread.bind(this)
-    if (!opts.firstModerator ) opts.firstModerator  = this._3id.getSubDID(this._name)
+    if (!opts.firstModerator) opts.firstModerator = this._3id.getSubDID(this._name)
     const thread = new Thread(this._orbitdb, namesTothreadName(this._name, name), this._3id, opts.members, opts.firstModerator, subscribeFn, this._ensureConnected)
     const address = thread._getThreadAddress()
     if (this._activeThreads[address]) return this._activeThreads[address]

--- a/src/thread.js
+++ b/src/thread.js
@@ -5,7 +5,7 @@ class Thread {
   /**
    * Please use **space.joinThread** to get the instance of this class
    */
-  constructor (orbitdb, name, threeId, membersOnly, rootMod, subscribe, ensureConnected) {
+  constructor (orbitdb, name, threeId, members, firstModerator, subscribe, ensureConnected) {
     this._orbitdb = orbitdb
     this._name = name
     this._spaceName = name.split('.')[2]
@@ -13,8 +13,8 @@ class Thread {
     this._subscribe = subscribe
     this._ensureConnected = ensureConnected
     this._queuedNewPosts = []
-    this._membersOnly = Boolean(membersOnly)
-    this._rootMod = rootMod || this._3id.getSubDID(this._spaceName)
+    this._members = Boolean(members)
+    this._firstModerator = firstModerator || this._3id.getSubDID(this._spaceName)
   }
 
   /**
@@ -25,7 +25,7 @@ class Thread {
    */
   async post (message) {
     this._requireLoad()
-    this._subscribe(this._address, { rootMod: this._rootMod, members: this._membersOnly, name: this._name })
+    this._subscribe(this._address, { firstModerator: this._firstModerator, members: this._members, name: this._name })
     this._ensureConnected(this._address, true)
     const timestamp = Math.floor(new Date().getTime() / 1000) // seconds
     return this._db.add({
@@ -36,6 +36,14 @@ class Thread {
 
   get address () {
     return this._db ? this._address : null
+  }
+
+  async _getThreadAddress () {
+    await this._initConfigs()
+    const address = (await this.orbitdb._determineAddress(this._name, 'feed', {
+      accessController: this._accessController
+    }, false)).toString()
+    this._address = address
   }
 
   /**
@@ -81,7 +89,7 @@ class Thread {
   }
 
   _throwIfNotMembers () {
-    if (!this._membersOnly) throw new Error('Thread: Not a members only thread, function not available')
+    if (!this._members) throw new Error('Thread: Not a members only thread, function not available')
   }
 
   /**
@@ -164,16 +172,11 @@ class Thread {
   }
 
   async _load (odbAddress) {
-    const identity = await this._3id.getOdbId(this._spaceName)
+    await this._initConfigs()
+    const identity = this._identity
     this._db = await this._orbitdb.feed(odbAddress || this._name, {
       identity,
-      accessController: {
-        type: 'thread-access',
-        threadName: this._name,
-        members: this._membersOnly,
-        rootMod: this._rootMod,
-        identity
-      }
+      accessController: this._accessController
     })
     await this._db.load()
     this._address = this._db.address.toString()
@@ -188,6 +191,18 @@ class Thread {
   async close () {
     this._requireLoad()
     await this._db.close()
+  }
+
+  async _initConfigs() {
+    if (this._identity) return
+    this._identity =  await this._3id.getOdbId(this._spaceName)
+    this._accessController =  {
+          type: 'thread-access',
+          threadName: this._name,
+          members: this._members,
+          firstModerator: this._firstModerator,
+          identity: this._identity
+        }
   }
 }
 


### PR DESCRIPTION
rodMod -> firstModerator
membersOnly -> members 
space._activeThreads by address instead of name 
refactor 3id mock for tests, old keyvalue store did mock failed, 3box test still failing, need to update 