### PR TITLE
Adds contentSignature option to getIdFromEthAddress

### DIFF
--- a/src/3box.js
+++ b/src/3box.js
@@ -400,6 +400,7 @@ class Box {
    * @param     {String}            opts.pinningNode        A string with an ipfs multi-address to a 3box pinning node
    * @param     {Object}            opts.ipfs               A js-ipfs ipfs object
    * @param     {String}            opts.addressServer      URL of the Address Server
+   * @param     {String}            opts.contentSignature   A signature, provided by a client of 3box using the private keys associated with the given address, of the 3box consent message
    * @return    {Box}                                       the 3Box instance for the given address
    */
   static async openBox (address, ethereumProvider, opts = {}) {

--- a/src/3id/__tests__/3id.test.js
+++ b/src/3id/__tests__/3id.test.js
@@ -25,9 +25,11 @@ const clearLocalStorage3id = (address) => {
 
 const ADDR_1 = '0x12345'
 const ADDR_2 = '0xabcde'
+const ADDR_3 = '0xlmnop'
 const ADDR_1_STATE_1 = '{"managementAddress":"0x12345","seed":"0xbc95bb0aeb7e5c7a9519ef066d4b60a944373ba1163b0c962a043bebec1579ef33e0ef4f63c0888d7a8ec95df34ada58fb739b2a4d3b44362747e6b193db9af2","spaceSeeds":{}}'
 const ADDR_1_STATE_2 = '{"managementAddress":"0x12345","seed":"0xbc95bb0aeb7e5c7a9519ef066d4b60a944373ba1163b0c962a043bebec1579ef33e0ef4f63c0888d7a8ec95df34ada58fb739b2a4d3b44362747e6b193db9af2","spaceSeeds":{"space1":"0xedfac8a7bcc52f33b88cfb9f310bc533f77800183beecfa49dcdf8d3b4b906502ec46533d9d7fb12eced9b04e0bdebd1c26872cf5fa759331e4c2f97ab95f450","space2":"0xedfac8a7bcc52f33b88cfb9f310bc533f77800183beecfa49dcdf8d3b4b906502ec46533d9d7fb12eced9b04e0bdebd1c26872cf5fa759331e4c2f97ab95f450"}}'
 const ADDR_2_STATE = '{"managementAddress":"0xabcde","seed":"0xbc95bb0aeb7e5c7a9519ef066d4b60a944373ba1163b0c962a043bebec1579ef33e0ef4f63c0888d7a8ec95df34ada58fb739b2a4d3b44362747e6b193db9af2","spaceSeeds":{}}'
+const ADDR_3_STATE_1 = '{"managementAddress":"0xlmnop","seed":"0xaedd3b597a14ad1c941ca535208fabd0b44a668dd0c8156f68a823ef8d713212d356731839a354ac5b781f4b986ff54aa2cadfa3551846c9e43bfa0122f3d55b","spaceSeeds":{}}'
 const SPACE_1 = 'space1'
 const SPACE_2 = 'space2'
 const ETHEREUM = 'mockEthProvider'
@@ -86,6 +88,36 @@ describe('3id', () => {
       expect(threeId.serializeState()).toEqual(ADDR_1_STATE_1)
       expect(opts.consentCallback).toHaveBeenCalledWith(false)
       expect(mockedUtils.openBoxConsent).toHaveBeenCalledTimes(0)
+    })
+
+    it('should create a new identity when passed a contentSignature', async () => {
+      const opts = { consentCallback: jest.fn(), contentSignature: '0xsomeContentSignature' }
+      const contentSignatureThreeId = await ThreeId.getIdFromEthAddress(ADDR_3, ETHEREUM, ipfs, opts)
+      expect(contentSignatureThreeId.serializeState()).toEqual(ADDR_3_STATE_1)
+      expect(contentSignatureThreeId.DID).toMatchSnapshot()
+      expect(opts.consentCallback).toHaveBeenCalledWith(true)
+      expect(mockedUtils.openBoxConsent).toHaveBeenCalledTimes(0)
+      expect(await resolve(contentSignatureThreeId.DID)).toMatchSnapshot()
+    })
+
+    it('should create the same identity given the same address and contentSignature', async () => {
+      // did is mocked, so compares serialized state
+      const opts = { contentSignature: '0xsomeContentSignature' }
+      const threeId1 = await ThreeId.getIdFromEthAddress(ADDR_3, ETHEREUM, ipfs, opts)
+      clearLocalStorage3id(ADDR_3)
+      const threeId2 = await ThreeId.getIdFromEthAddress(ADDR_3, ETHEREUM, ipfs, opts)
+      expect(mockedUtils.openBoxConsent).toHaveBeenCalledTimes(0)
+      expect(threeId1.serializeState()).toEqual(threeId2.serializeState())
+    })
+
+    it('should NOT create the same identity given the same address but a different contentSignature', async () => {
+      // did is mocked, so compares serialized state
+      const opts = { contentSignature: '0xsomeIncorrectSignature' }
+      const threeId1 = await ThreeId.getIdFromEthAddress(ADDR_3, ETHEREUM, ipfs, opts)
+      clearLocalStorage3id(ADDR_3)
+      const threeId2 = await ThreeId.getIdFromEthAddress(ADDR_3, ETHEREUM, ipfs, opts)
+      expect(mockedUtils.openBoxConsent).toHaveBeenCalledTimes(0)
+      expect(threeId1.serializeState()).not.toEqual(threeId2.serializeState())
     })
   })
 

--- a/src/3id/__tests__/3id.test.js
+++ b/src/3id/__tests__/3id.test.js
@@ -33,6 +33,8 @@ const ADDR_3_STATE_1 = '{"managementAddress":"0xlmnop","seed":"0xaedd3b597a14ad1
 const SPACE_1 = 'space1'
 const SPACE_2 = 'space2'
 const ETHEREUM = 'mockEthProvider'
+const CONTENT_SIGNATURE_1 = '0xsomeContentSignature'
+const NOT_CONTENT_SIGNATURE_1 = '0xanIncorrectSignature'
 
 const mockedUtils = require('../../utils/index')
 
@@ -91,7 +93,7 @@ describe('3id', () => {
     })
 
     it('should create a new identity when passed a contentSignature', async () => {
-      const opts = { consentCallback: jest.fn(), contentSignature: '0xsomeContentSignature' }
+      const opts = { consentCallback: jest.fn(), contentSignature: CONTENT_SIGNATURE_1 }
       const contentSignatureThreeId = await ThreeId.getIdFromEthAddress(ADDR_3, ETHEREUM, ipfs, opts)
       expect(contentSignatureThreeId.serializeState()).toEqual(ADDR_3_STATE_1)
       expect(contentSignatureThreeId.DID).toMatchSnapshot()
@@ -102,7 +104,7 @@ describe('3id', () => {
 
     it('should create the same identity given the same address and contentSignature', async () => {
       // did is mocked, so compares serialized state
-      const opts = { contentSignature: '0xsomeContentSignature' }
+      const opts = { contentSignature: CONTENT_SIGNATURE_1 }
       const threeId1 = await ThreeId.getIdFromEthAddress(ADDR_3, ETHEREUM, ipfs, opts)
       clearLocalStorage3id(ADDR_3)
       const threeId2 = await ThreeId.getIdFromEthAddress(ADDR_3, ETHEREUM, ipfs, opts)
@@ -112,7 +114,7 @@ describe('3id', () => {
 
     it('should NOT create the same identity given the same address but a different contentSignature', async () => {
       // did is mocked, so compares serialized state
-      const opts = { contentSignature: '0xsomeIncorrectSignature' }
+      const opts = { contentSignature: NOT_CONTENT_SIGNATURE_1 }
       const threeId1 = await ThreeId.getIdFromEthAddress(ADDR_3, ETHEREUM, ipfs, opts)
       clearLocalStorage3id(ADDR_3)
       const threeId2 = await ThreeId.getIdFromEthAddress(ADDR_3, ETHEREUM, ipfs, opts)

--- a/src/3id/__tests__/__snapshots__/3id.test.js.snap
+++ b/src/3id/__tests__/__snapshots__/3id.test.js.snap
@@ -32,6 +32,38 @@ Object {
 }
 `;
 
+exports[`3id getIdFromEthAddress should create a new identity when passed a contentSignature 1`] = `"did:3:bafyreiacmttqrvqnlv5ig2zyxgwk2zyb2kmr5uymio6z2efmfmbmztowyq"`;
+
+exports[`3id getIdFromEthAddress should create a new identity when passed a contentSignature 2`] = `
+Object {
+  "@context": "https://w3id.org/did/v1",
+  "authentication": Array [
+    Object {
+      "publicKey": "did:3:bafyreiacmttqrvqnlv5ig2zyxgwk2zyb2kmr5uymio6z2efmfmbmztowyq#signingKey",
+      "type": "Secp256k1SignatureAuthentication2018",
+    },
+  ],
+  "id": "did:3:bafyreiacmttqrvqnlv5ig2zyxgwk2zyb2kmr5uymio6z2efmfmbmztowyq",
+  "publicKey": Array [
+    Object {
+      "id": "did:3:bafyreiacmttqrvqnlv5ig2zyxgwk2zyb2kmr5uymio6z2efmfmbmztowyq#signingKey",
+      "publicKeyHex": "04f946a2d88587620c5f35ed454b56693f889143eb8b6a09add775323ee48eea50f975da450eb17e84bbc7789d5a5e2e81b801d518738aa2296b97085543b92162",
+      "type": "Secp256k1VerificationKey2018",
+    },
+    Object {
+      "id": "did:3:bafyreiacmttqrvqnlv5ig2zyxgwk2zyb2kmr5uymio6z2efmfmbmztowyq#encryptionKey",
+      "publicKeyBase64": "Pr8/CUkw2aisoqnMSJkeOggGD51YwFR0DLrvyeWvhH8=",
+      "type": "Curve25519EncryptionPublicKey",
+    },
+    Object {
+      "ethereumAddress": "0xlmnop",
+      "id": "did:3:bafyreiacmttqrvqnlv5ig2zyxgwk2zyb2kmr5uymio6z2efmfmbmztowyq#managementKey",
+      "type": "Secp256k1VerificationKey2018",
+    },
+  ],
+}
+`;
+
 exports[`3id keyring logic should init space keyrings correctly 1`] = `"did:3:bafyreig4qyx4p5kscxzextx6icfapqwhlryo64m6sfacy67jnuwnfyludy"`;
 
 exports[`3id keyring logic should init space keyrings correctly 2`] = `

--- a/src/3id/index.js
+++ b/src/3id/index.js
@@ -181,7 +181,12 @@ class ThreeId {
     if (serialized3id) {
       if (opts.consentCallback) opts.consentCallback(false)
     } else {
-      const sig = await utils.openBoxConsent(normalizedAddress, ethereum)
+      let sig
+      if (opts.contentSignature) {
+        sig = opts.contentSignature
+      } else {
+        sig = await utils.openBoxConsent(normalizedAddress, ethereum)
+      }
       if (opts.consentCallback) opts.consentCallback(true)
       const entropy = '0x' + utils.sha256(sig.slice(2))
       const mnemonic = HDNode.entropyToMnemonic(entropy)


### PR DESCRIPTION
Resolves https://github.com/3box/3box-js/issues/528

This PR adds a contentSignature option to the `getIdFromEthAddress` method in `3id.js`

This can enable wallets to provide signatures for authorizing 3box as an option when creating a new 3box instance, thereby removing the need for user action to confirm the signature.

The PR also updates documentation for `openBox` in `3box.js` and adds unit tests to cover the new functionality of `getIdFromEthAddress`