### PR TITLE
fix: refine rootstore sync logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3box",
-  "version": "1.10.4",
+  "version": "1.10.5-beta.2",
   "description": "Interact with user data",
   "main": "lib/3box.js",
   "directories": {


### PR DESCRIPTION
Basically we should wait for the rootstore to be synced before we do the `onSyncDone` callback.

This PR has the following changes:
* Listen for `HAS_ENTRIES` message for rootstore and wait until the rootstore is fully synced
* If `numEntries === 0` we know that it's a new user and we call `onSyncDone` directly
* `_createRootStore` which adds the entries for the public and private store is now added after `onSyncDone` has happened (the rootstore is fully synced)