### PR TITLE
feat: verify proof if given to linkAddress method

### DIFF
--- a/src/3box.js
+++ b/src/3box.js
@@ -365,6 +365,17 @@ class Box {
    */
   async linkAddress (link = {}) {
     if (link.proof) {
+      let valid
+      if (link.proof.type === ACCOUNT_TYPES.ethereumEOA) {
+        valid = await utils.recoverPersonalSign(link.proof.message, link.proof.signature)
+      } else if (link.proof.type === ACCOUNT_TYPES.erc1271) {
+        valid = await utils.isValidSignature(link.proof, true, this._web3provider)
+      } else {
+        throw new Error('Missing or invalid property "type" in proof')
+      }
+      if (!valid) {
+        throw new Error('There was an issue verifying the supplied proof: ', valid)
+      }
       await this._writeRootstoreEntry(Replicator.entryTypes.ADDRESS_LINK, link.proof)
       return
     }


### PR DESCRIPTION
Simply just add a call to verify signature of proof and wrap it in the catch block. This will prevent errors by developers adding an invalid proof, which might break a users 3box.