### PR TITLE
feat: check if provider is metamask in has3idSupport

### DIFF
--- a/src/3id/index.js
+++ b/src/3id/index.js
@@ -305,6 +305,7 @@ class ThreeId {
 }
 
 const has3idSupport = async provider => {
+  if (provider.isMetaMask) return false
   try {
     await utils.callRpc(provider, '3id_getLink')
     // no error thrown, provider has 3id support


### PR DESCRIPTION
If the provider is metamask we don't have to send the rpc request asking for 3ID rpc support.