### PR TITLE
Bugfix: eth_getCode add second parameter "latest"

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -122,7 +122,7 @@ module.exports = {
 
   getCode: async (ethereumProvider, address) => {
     const method = 'eth_getCode'
-    const params = [address]
+    const params = [address, 'latest']
 
     const code = await safeSend(ethereumProvider, {
       jsonrpc: '2.0',


### PR DESCRIPTION
Without the second parameter infura `Geth/v1.8.27-omnibus-c94f741c/linux-amd64/go1.11.1` returns an error:
```
"code": -32602,
"message": "missing value for required argument 1"
```
Parity seems to have no problem with the missing parameter.