### PR TITLE
ref(api): move static api functions to separate class

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,10 +284,11 @@ idUtils.verifyClaim(claim)
 ## <a name="api"></a> API Documentation
 <a name="Box"></a>
 
-### Box
+### Box ⇐ [<code>BoxApi</code>](#BoxApi)
 **Kind**: global class  
+**Extends**: [<code>BoxApi</code>](#BoxApi)  
 
-* [Box](#Box)
+* [Box](#Box) ⇐ [<code>BoxApi</code>](#BoxApi)
     * [new Box()](#new_Box_new)
     * _instance_
         * [.public](#Box+public)
@@ -308,15 +309,6 @@ idUtils.verifyClaim(claim)
             * [.verifyClaim](#Box.idUtils.verifyClaim) ⇒ <code>Object</code>
             * [.isSupportedDID(did)](#Box.idUtils.isSupportedDID) ⇒ <code>\*</code> \| <code>boolean</code>
             * [.isClaim(claim, opts)](#Box.idUtils.isClaim) ⇒ <code>Promise.&lt;boolean&gt;</code>
-        * [.getProfile(address, opts)](#Box.getProfile) ⇒ <code>Object</code>
-        * [.getProfiles(address, opts)](#Box.getProfiles) ⇒ <code>Object</code>
-        * [.getSpace(address, name, opts)](#Box.getSpace) ⇒ <code>Object</code>
-        * [.getThread(space, name, firstModerator, members, opts)](#Box.getThread) ⇒ <code>Array.&lt;Object&gt;</code>
-        * [.getThreadByAddress(address, opts)](#Box.getThreadByAddress) ⇒ <code>Array.&lt;Object&gt;</code>
-        * [.getConfig(address, opts)](#Box.getConfig) ⇒ <code>Array.&lt;Object&gt;</code>
-        * [.listSpaces(address, opts)](#Box.listSpaces) ⇒ <code>Object</code>
-        * [.profileGraphQL(query, opts)](#Box.profileGraphQL) ⇒ <code>Object</code>
-        * [.getVerifiedAccounts(profile)](#Box.getVerifiedAccounts) ⇒ <code>Object</code>
         * [.openBox(address, provider, opts)](#Box.openBox) ⇒ [<code>Box</code>](#Box)
         * [.isLoggedIn(address)](#Box.isLoggedIn) ⇒ <code>Boolean</code>
         * [.getIPFS()](#Box.getIPFS) ⇒ <code>IPFS</code>
@@ -517,141 +509,6 @@ Check whether a string is a valid claim or not
 | opts | <code>Object</code> | Optional parameters |
 | opts.audience | <code>string</code> | The DID of the audience of the JWT |
 
-<a name="Box.getProfile"></a>
-
-#### Box.getProfile(address, opts) ⇒ <code>Object</code>
-Get the public profile of a given address
-
-**Kind**: static method of [<code>Box</code>](#Box)  
-**Returns**: <code>Object</code> - a json object with the profile for the given address  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| address | <code>String</code> | An ethereum address |
-| opts | <code>Object</code> | Optional parameters |
-| opts.blocklist | <code>function</code> | A function that takes an address and returns true if the user has been blocked |
-| opts.metadata | <code>String</code> | flag to retrieve metadata |
-| opts.addressServer | <code>String</code> | URL of the Address Server |
-| opts.ipfs | <code>Object</code> | A js-ipfs ipfs object |
-| opts.useCacheService | <code>Boolean</code> | Use 3Box API and Cache Service to fetch profile instead of OrbitDB. Default true. |
-| opts.profileServer | <code>String</code> | URL of Profile API server |
-
-<a name="Box.getProfiles"></a>
-
-#### Box.getProfiles(address, opts) ⇒ <code>Object</code>
-Get a list of public profiles for given addresses. This relies on 3Box profile API.
-
-**Kind**: static method of [<code>Box</code>](#Box)  
-**Returns**: <code>Object</code> - a json object with each key an address and value the profile  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| address | <code>Array</code> | An array of ethereum addresses |
-| opts | <code>Object</code> | Optional parameters |
-| opts.profileServer | <code>String</code> | URL of Profile API server |
-
-<a name="Box.getSpace"></a>
-
-#### Box.getSpace(address, name, opts) ⇒ <code>Object</code>
-Get the public data in a space of a given address with the given name
-
-**Kind**: static method of [<code>Box</code>](#Box)  
-**Returns**: <code>Object</code> - a json object with the public space data  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| address | <code>String</code> | An ethereum address |
-| name | <code>String</code> | A space name |
-| opts | <code>Object</code> | Optional parameters |
-| opts.blocklist | <code>function</code> | A function that takes an address and returns true if the user has been blocked |
-| opts.metadata | <code>String</code> | flag to retrieve metadata |
-| opts.profileServer | <code>String</code> | URL of Profile API server |
-
-<a name="Box.getThread"></a>
-
-#### Box.getThread(space, name, firstModerator, members, opts) ⇒ <code>Array.&lt;Object&gt;</code>
-Get all posts that are made to a thread.
-
-**Kind**: static method of [<code>Box</code>](#Box)  
-**Returns**: <code>Array.&lt;Object&gt;</code> - An array of posts  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| space | <code>String</code> | The name of the space the thread is in |
-| name | <code>String</code> | The name of the thread |
-| firstModerator | <code>String</code> | The DID (or ethereum address) of the first moderator |
-| members | <code>Boolean</code> | True if only members are allowed to post |
-| opts | <code>Object</code> | Optional parameters |
-| opts.profileServer | <code>String</code> | URL of Profile API server |
-
-<a name="Box.getThreadByAddress"></a>
-
-#### Box.getThreadByAddress(address, opts) ⇒ <code>Array.&lt;Object&gt;</code>
-Get all posts that are made to a thread.
-
-**Kind**: static method of [<code>Box</code>](#Box)  
-**Returns**: <code>Array.&lt;Object&gt;</code> - An array of posts  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| address | <code>String</code> | The orbitdb-address of the thread |
-| opts | <code>Object</code> | Optional parameters |
-| opts.profileServer | <code>String</code> | URL of Profile API server |
-
-<a name="Box.getConfig"></a>
-
-#### Box.getConfig(address, opts) ⇒ <code>Array.&lt;Object&gt;</code>
-Get the configuration of a users 3Box
-
-**Kind**: static method of [<code>Box</code>](#Box)  
-**Returns**: <code>Array.&lt;Object&gt;</code> - An array of posts  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| address | <code>String</code> | The ethereum address |
-| opts | <code>Object</code> | Optional parameters |
-| opts.profileServer | <code>String</code> | URL of Profile API server |
-
-<a name="Box.listSpaces"></a>
-
-#### Box.listSpaces(address, opts) ⇒ <code>Object</code>
-Get the names of all spaces a user has
-
-**Kind**: static method of [<code>Box</code>](#Box)  
-**Returns**: <code>Object</code> - an array with all spaces as strings  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| address | <code>String</code> | An ethereum address |
-| opts | <code>Object</code> | Optional parameters |
-| opts.profileServer | <code>String</code> | URL of Profile API server |
-
-<a name="Box.profileGraphQL"></a>
-
-#### Box.profileGraphQL(query, opts) ⇒ <code>Object</code>
-GraphQL for 3Box profile API
-
-**Kind**: static method of [<code>Box</code>](#Box)  
-**Returns**: <code>Object</code> - a json object with each key an address and value the profile  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| query | <code>Object</code> | A graphQL query object. |
-| opts | <code>Object</code> | Optional parameters |
-| opts.graphqlServer | <code>String</code> | URL of graphQL 3Box profile service |
-
-<a name="Box.getVerifiedAccounts"></a>
-
-#### Box.getVerifiedAccounts(profile) ⇒ <code>Object</code>
-Verifies the proofs of social accounts that is present in the profile.
-
-**Kind**: static method of [<code>Box</code>](#Box)  
-**Returns**: <code>Object</code> - An object containing the accounts that have been verified  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| profile | <code>Object</code> | A user profile object, received from the `getProfile` function |
-
 <a name="Box.openBox"></a>
 
 #### Box.openBox(address, provider, opts) ⇒ [<code>Box</code>](#Box)
@@ -690,6 +547,154 @@ Instanciate ipfs used by 3Box without calling openBox.
 
 **Kind**: static method of [<code>Box</code>](#Box)  
 **Returns**: <code>IPFS</code> - the ipfs instance  
+<a name="BoxApi"></a>
+
+### BoxApi
+**Kind**: global class  
+
+* [BoxApi](#BoxApi)
+    * [.listSpaces(address, opts)](#BoxApi.listSpaces) ⇒ <code>Object</code>
+    * [.getSpace(address, name, opts)](#BoxApi.getSpace) ⇒ <code>Object</code>
+    * [.getThread(space, name, firstModerator, members, opts)](#BoxApi.getThread) ⇒ <code>Array.&lt;Object&gt;</code>
+    * [.getThreadByAddress(address, opts)](#BoxApi.getThreadByAddress) ⇒ <code>Array.&lt;Object&gt;</code>
+    * [.getConfig(address, opts)](#BoxApi.getConfig) ⇒ <code>Array.&lt;Object&gt;</code>
+    * [.getProfile(address, opts)](#BoxApi.getProfile) ⇒ <code>Object</code>
+    * [.getProfiles(address, opts)](#BoxApi.getProfiles) ⇒ <code>Object</code>
+    * [.profileGraphQL(query, opts)](#BoxApi.profileGraphQL) ⇒ <code>Object</code>
+    * [.getVerifiedAccounts(profile)](#BoxApi.getVerifiedAccounts) ⇒ <code>Object</code>
+
+<a name="BoxApi.listSpaces"></a>
+
+#### BoxApi.listSpaces(address, opts) ⇒ <code>Object</code>
+Get the names of all spaces a user has
+
+**Kind**: static method of [<code>BoxApi</code>](#BoxApi)  
+**Returns**: <code>Object</code> - an array with all spaces as strings  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| address | <code>String</code> | An ethereum address |
+| opts | <code>Object</code> | Optional parameters |
+| opts.profileServer | <code>String</code> | URL of Profile API server |
+
+<a name="BoxApi.getSpace"></a>
+
+#### BoxApi.getSpace(address, name, opts) ⇒ <code>Object</code>
+Get the public data in a space of a given address with the given name
+
+**Kind**: static method of [<code>BoxApi</code>](#BoxApi)  
+**Returns**: <code>Object</code> - a json object with the public space data  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| address | <code>String</code> | An ethereum address |
+| name | <code>String</code> | A space name |
+| opts | <code>Object</code> | Optional parameters |
+| opts.blocklist | <code>function</code> | A function that takes an address and returns true if the user has been blocked |
+| opts.metadata | <code>String</code> | flag to retrieve metadata |
+| opts.profileServer | <code>String</code> | URL of Profile API server |
+
+<a name="BoxApi.getThread"></a>
+
+#### BoxApi.getThread(space, name, firstModerator, members, opts) ⇒ <code>Array.&lt;Object&gt;</code>
+Get all posts that are made to a thread.
+
+**Kind**: static method of [<code>BoxApi</code>](#BoxApi)  
+**Returns**: <code>Array.&lt;Object&gt;</code> - An array of posts  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| space | <code>String</code> | The name of the space the thread is in |
+| name | <code>String</code> | The name of the thread |
+| firstModerator | <code>String</code> | The DID (or ethereum address) of the first moderator |
+| members | <code>Boolean</code> | True if only members are allowed to post |
+| opts | <code>Object</code> | Optional parameters |
+| opts.profileServer | <code>String</code> | URL of Profile API server |
+
+<a name="BoxApi.getThreadByAddress"></a>
+
+#### BoxApi.getThreadByAddress(address, opts) ⇒ <code>Array.&lt;Object&gt;</code>
+Get all posts that are made to a thread.
+
+**Kind**: static method of [<code>BoxApi</code>](#BoxApi)  
+**Returns**: <code>Array.&lt;Object&gt;</code> - An array of posts  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| address | <code>String</code> | The orbitdb-address of the thread |
+| opts | <code>Object</code> | Optional parameters |
+| opts.profileServer | <code>String</code> | URL of Profile API server |
+
+<a name="BoxApi.getConfig"></a>
+
+#### BoxApi.getConfig(address, opts) ⇒ <code>Array.&lt;Object&gt;</code>
+Get the configuration of a users 3Box
+
+**Kind**: static method of [<code>BoxApi</code>](#BoxApi)  
+**Returns**: <code>Array.&lt;Object&gt;</code> - An array of posts  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| address | <code>String</code> | The ethereum address |
+| opts | <code>Object</code> | Optional parameters |
+| opts.profileServer | <code>String</code> | URL of Profile API server |
+
+<a name="BoxApi.getProfile"></a>
+
+#### BoxApi.getProfile(address, opts) ⇒ <code>Object</code>
+Get the public profile of a given address
+
+**Kind**: static method of [<code>BoxApi</code>](#BoxApi)  
+**Returns**: <code>Object</code> - a json object with the profile for the given address  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| address | <code>String</code> | An ethereum address |
+| opts | <code>Object</code> | Optional parameters |
+| opts.blocklist | <code>function</code> | A function that takes an address and returns true if the user has been blocked |
+| opts.metadata | <code>String</code> | flag to retrieve metadata |
+| opts.profileServer | <code>String</code> | URL of Profile API server |
+
+<a name="BoxApi.getProfiles"></a>
+
+#### BoxApi.getProfiles(address, opts) ⇒ <code>Object</code>
+Get a list of public profiles for given addresses. This relies on 3Box profile API.
+
+**Kind**: static method of [<code>BoxApi</code>](#BoxApi)  
+**Returns**: <code>Object</code> - a json object with each key an address and value the profile  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| address | <code>Array</code> | An array of ethereum addresses |
+| opts | <code>Object</code> | Optional parameters |
+| opts.profileServer | <code>String</code> | URL of Profile API server |
+
+<a name="BoxApi.profileGraphQL"></a>
+
+#### BoxApi.profileGraphQL(query, opts) ⇒ <code>Object</code>
+GraphQL for 3Box profile API
+
+**Kind**: static method of [<code>BoxApi</code>](#BoxApi)  
+**Returns**: <code>Object</code> - a json object with each key an address and value the profile  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| query | <code>Object</code> | A graphQL query object. |
+| opts | <code>Object</code> | Optional parameters |
+| opts.graphqlServer | <code>String</code> | URL of graphQL 3Box profile service |
+
+<a name="BoxApi.getVerifiedAccounts"></a>
+
+#### BoxApi.getVerifiedAccounts(profile) ⇒ <code>Object</code>
+Verifies the proofs of social accounts that is present in the profile.
+
+**Kind**: static method of [<code>BoxApi</code>](#BoxApi)  
+**Returns**: <code>Object</code> - An object containing the accounts that have been verified  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| profile | <code>Object</code> | A user profile object, received from the `getProfile` function |
+
 <a name="KeyValueStore"></a>
 
 ### KeyValueStore

--- a/src/api.js
+++ b/src/api.js
@@ -8,171 +8,257 @@ const GRAPHQL_SERVER_URL = config.graphql_server_url
 const PROFILE_SERVER_URL = config.profile_server_url
 const ADDRESS_SERVER_URL = config.address_server_url
 
-async function getRootStoreAddress (identifier, serverUrl = ADDRESS_SERVER_URL) {
-  // read orbitdb root store address from the 3box-address-server
-  const res = await utils.fetchJson(serverUrl + '/odbAddress/' + identifier)
-  return res.data.rootStoreAddress
-}
-
-async function listSpaces (address, serverUrl = PROFILE_SERVER_URL) {
-  try {
-    // we await explicitly here to make sure the error is catch'd in the correct scope
-    if (isSupportedDID(address)) {
-      return await utils.fetchJson(serverUrl + '/list-spaces?did=' + address)
-    } else {
-      return await utils.fetchJson(serverUrl + '/list-spaces?address=' + encodeURIComponent(address))
-    }
-  } catch (err) {
-    return []
+/**
+ * @class
+ */
+class BoxApi {
+  static async getRootStoreAddress (identifier, serverUrl = ADDRESS_SERVER_URL) {
+    // read orbitdb root store address from the 3box-address-server
+    const res = await utils.fetchJson(serverUrl + '/odbAddress/' + identifier)
+    return res.data.rootStoreAddress
   }
-}
 
-async function getSpace (address, name, serverUrl = PROFILE_SERVER_URL, { metadata, blocklist } = {}) {
-  if (blocklist && blocklist(address)) throw new Error(`user with ${address} is blocked`)
-  let url = `${serverUrl}/space`
-
-  try {
-    // Add first parameter: address or did
-    if (isSupportedDID(address)) {
-      url = `${url}?did=${address}`
-    } else {
-      url = `${url}?address=${encodeURIComponent(address.toLowerCase())}`
-    }
-
-    // Add name:
-    url = `${url}&name=${encodeURIComponent(name)}`
-
-    // Add metadata:
-    if (metadata) {
-      url = `${url}&metadata=${encodeURIComponent(metadata)}`
-    }
-
-    // Query:
-    // we await explicitly to make sure the error is catch'd in the correct scope
-    return await utils.fetchJson(url)
-  } catch (err) {
-    return {}
-  }
-}
-
-// TODO consumes address now, could also give root DID to get space DID
-async function getSpaceDID (address, space, opts = {}) {
-  const conf = await getConfig(address, opts)
-  if (!conf.spaces[space] || !conf.spaces[space].DID) throw new Error(`Could not find appropriate DID for address ${address}`)
-  return conf.spaces[space].DID
-}
-
-async function getThread (space, name, firstModerator, members, opts = {}) {
-  const serverUrl = opts.profileServer || PROFILE_SERVER_URL
-  if (firstModerator.startsWith('0x')) {
-    firstModerator = await getSpaceDID(firstModerator, space, opts)
-  }
-  try {
-    let url = `${serverUrl}/thread?space=${encodeURIComponent(space)}&name=${encodeURIComponent(name)}`
-    url += `&mod=${encodeURIComponent(firstModerator)}&members=${encodeURIComponent(members)}`
-    return await utils.fetchJson(url)
-  } catch (err) {
-    throw new Error(err)
-  }
-}
-
-async function getThreadByAddress (address, opts = {}) {
-  const serverUrl = opts.profileServer || PROFILE_SERVER_URL
-  try {
-    return await utils.fetchJson(`${serverUrl}/thread?address=${encodeURIComponent(address)}`)
-  } catch (err) {
-    throw new Error(err)
-  }
-}
-
-async function getConfig (address, opts = {}) {
-  const serverUrl = opts.profileServer || PROFILE_SERVER_URL
-  try {
-    return await utils.fetchJson(`${serverUrl}/config?address=${encodeURIComponent(address)}`)
-  } catch (err) {
-    throw new Error(err)
-  }
-}
-
-async function getProfile (address, serverUrl = PROFILE_SERVER_URL, { metadata, blocklist } = {}) {
-  if (blocklist && blocklist(address)) throw new Error(`user with ${address} is blocked`)
-  let url = `${serverUrl}/profile`
-
-  try {
-    // Add first parameter: address or did
-    if (isSupportedDID(address)) {
-      url = `${url}?did=${address}`
-    } else {
-      url = `${url}?address=${encodeURIComponent(address.toLowerCase())}`
-    }
-
-    // Add metadata:
-    if (metadata) {
-      url = `${url}&metadata=${encodeURIComponent(metadata)}`
-    }
-
-    // Query:
-    // we await explicitly to make sure the error is catch'd in the correct scope
-    return await utils.fetchJson(url)
-  } catch (err) {
-    return {} // empty profile
-  }
-}
-
-async function getProfiles (addressArray, opts = {}) {
-  opts = Object.assign({ profileServer: PROFILE_SERVER_URL }, opts)
-  const req = { addressList: [], didList: [] }
-
-  // Split addresses on ethereum / dids
-  addressArray.forEach(address => {
-    if (isSupportedDID(address)) {
-      req.didList.push(address)
-    } else {
-      req.addressList.push(address)
-    }
-  })
-
-  const url = `${opts.profileServer}/profileList`
-  return utils.fetchJson(url, req)
-}
-
-async function profileGraphQL (query, opts = {}) {
-  opts = Object.assign({ graphqlServer: GRAPHQL_SERVER_URL }, opts)
-  return graphQLRequest(opts.graphqlServer, query)
-}
-
-async function getVerifiedAccounts (profile) {
-  const verifs = {}
-  try {
-    const did = await verifier.verifyDID(profile.proof_did)
-
-    verifs.did = did
-
-    if (profile.proof_github) {
-      try {
-        verifs.github = await verifier.verifyGithub(did, profile.proof_github)
-      } catch (err) {
-        // Invalid github verification
+  /**
+   * Get the names of all spaces a user has
+   *
+   * @param     {String}    address                 An ethereum address
+   * @param     {Object}    opts                    Optional parameters
+   * @param     {String}    opts.profileServer      URL of Profile API server
+   * @return    {Object}                            an array with all spaces as strings
+   */
+  static async listSpaces (address, { profileServer } = {}) {
+    const serverUrl = profileServer || PROFILE_SERVER_URL
+    try {
+      // we await explicitly here to make sure the error is catch'd in the correct scope
+      if (isSupportedDID(address)) {
+        return await utils.fetchJson(serverUrl + '/list-spaces?did=' + address)
+      } else {
+        return await utils.fetchJson(serverUrl + '/list-spaces?address=' + encodeURIComponent(address))
       }
+    } catch (err) {
+      return []
     }
-    if (profile.proof_twitter) {
-      try {
-        verifs.twitter = await verifier.verifyTwitter(did, profile.proof_twitter)
-      } catch (err) {
-        // Invalid twitter verification
-      }
-    }
-    if (profile.ethereum_proof) {
-      try {
-        verifs.ethereum = await verifier.verifyEthereum(profile.ethereum_proof, did)
-      } catch (err) {
-        // Invalid eth verification
-      }
-    }
-  } catch (err) {
-    // Invalid proof for DID return an empty profile
   }
-  return verifs
+
+  /**
+   * Get the public data in a space of a given address with the given name
+   *
+   * @param     {String}    address                 An ethereum address
+   * @param     {String}    name                    A space name
+   * @param     {Object}    opts                    Optional parameters
+   * @param     {Function}  opts.blocklist          A function that takes an address and returns true if the user has been blocked
+   * @param     {String}    opts.metadata           flag to retrieve metadata
+   * @param     {String}    opts.profileServer      URL of Profile API server
+   * @return    {Object}                            a json object with the public space data
+   */
+  static async getSpace (address, name, { profileServer, metadata, blocklist } = {}) {
+    if (blocklist && blocklist(address)) throw new Error(`user with ${address} is blocked`)
+    const serverUrl = profileServer || PROFILE_SERVER_URL
+    let url = `${serverUrl}/space`
+
+    try {
+      // Add first parameter: address or did
+      if (isSupportedDID(address)) {
+        url = `${url}?did=${address}`
+      } else {
+        url = `${url}?address=${encodeURIComponent(address.toLowerCase())}`
+      }
+
+      // Add name:
+      url = `${url}&name=${encodeURIComponent(name)}`
+
+      // Add metadata:
+      if (metadata) {
+        url = `${url}&metadata=${encodeURIComponent(metadata)}`
+      }
+
+      // Query:
+      // we await explicitly to make sure the error is catch'd in the correct scope
+      return await utils.fetchJson(url)
+    } catch (err) {
+      return {}
+    }
+  }
+
+  // TODO consumes address now, could also give root DID to get space DID
+  static async getSpaceDID (address, space, opts = {}) {
+    const conf = await BoxApi.getConfig(address, opts)
+    if (!conf.spaces[space] || !conf.spaces[space].DID) throw new Error(`Could not find appropriate DID for address ${address}`)
+    return conf.spaces[space].DID
+  }
+
+  /**
+   * Get all posts that are made to a thread.
+   *
+   * @param     {String}    space                   The name of the space the thread is in
+   * @param     {String}    name                    The name of the thread
+   * @param     {String}    firstModerator          The DID (or ethereum address) of the first moderator
+   * @param     {Boolean}   members                 True if only members are allowed to post
+   * @param     {Object}    opts                    Optional parameters
+   * @param     {String}    opts.profileServer      URL of Profile API server
+   * @return    {Array<Object>}                     An array of posts
+   */
+  static async getThread (space, name, firstModerator, members, opts = {}) {
+    const serverUrl = opts.profileServer || PROFILE_SERVER_URL
+    if (firstModerator.startsWith('0x')) {
+      firstModerator = await BoxApi.getSpaceDID(firstModerator, space, opts)
+    }
+    try {
+      let url = `${serverUrl}/thread?space=${encodeURIComponent(space)}&name=${encodeURIComponent(name)}`
+      url += `&mod=${encodeURIComponent(firstModerator)}&members=${encodeURIComponent(members)}`
+      return await utils.fetchJson(url)
+    } catch (err) {
+      throw new Error(err)
+    }
+  }
+
+  /**
+   * Get all posts that are made to a thread.
+   *
+   * @param     {String}    address                 The orbitdb-address of the thread
+   * @param     {Object}    opts                    Optional parameters
+   * @param     {String}    opts.profileServer      URL of Profile API server
+   * @return    {Array<Object>}                     An array of posts
+   */
+  static async getThreadByAddress (address, opts = {}) {
+    const serverUrl = opts.profileServer || PROFILE_SERVER_URL
+    try {
+      return await utils.fetchJson(`${serverUrl}/thread?address=${encodeURIComponent(address)}`)
+    } catch (err) {
+      throw new Error(err)
+    }
+  }
+
+  /**
+   * Get the configuration of a users 3Box
+   *
+   * @param     {String}    address                 The ethereum address
+   * @param     {Object}    opts                    Optional parameters
+   * @param     {String}    opts.profileServer      URL of Profile API server
+   * @return    {Array<Object>}                     An array of posts
+   */
+  static async getConfig (address, opts = {}) {
+    const serverUrl = opts.profileServer || PROFILE_SERVER_URL
+    try {
+      return await utils.fetchJson(`${serverUrl}/config?address=${encodeURIComponent(address)}`)
+    } catch (err) {
+      throw new Error(err)
+    }
+  }
+
+  /**
+   * Get the public profile of a given address
+   *
+   * @param     {String}    address                 An ethereum address
+   * @param     {Object}    opts                    Optional parameters
+   * @param     {Function}  opts.blocklist          A function that takes an address and returns true if the user has been blocked
+   * @param     {String}    opts.metadata           flag to retrieve metadata
+   * @param     {String}    opts.profileServer      URL of Profile API server
+   * @return    {Object}                            a json object with the profile for the given address
+   */
+  static async getProfile (address, { profileServer, metadata, blocklist } = {}) {
+    if (blocklist && blocklist(address)) throw new Error(`user with ${address} is blocked`)
+    const serverUrl = profileServer || PROFILE_SERVER_URL
+    let url = `${serverUrl}/profile`
+
+    try {
+      // Add first parameter: address or did
+      if (isSupportedDID(address)) {
+        url = `${url}?did=${address}`
+      } else {
+        url = `${url}?address=${encodeURIComponent(address.toLowerCase())}`
+      }
+
+      // Add metadata:
+      if (metadata) {
+        url = `${url}&metadata=${encodeURIComponent(metadata)}`
+      }
+
+      // Query:
+      // we await explicitly to make sure the error is catch'd in the correct scope
+      return await utils.fetchJson(url)
+    } catch (err) {
+      return {} // empty profile
+    }
+  }
+
+  /**
+   * Get a list of public profiles for given addresses. This relies on 3Box profile API.
+   *
+   * @param     {Array}     address                 An array of ethereum addresses
+   * @param     {Object}    opts                    Optional parameters
+   * @param     {String}    opts.profileServer      URL of Profile API server
+   * @return    {Object}                            a json object with each key an address and value the profile
+   */
+  static async getProfiles (addressArray, opts = {}) {
+    opts = Object.assign({ profileServer: PROFILE_SERVER_URL }, opts)
+    const req = { addressList: [], didList: [] }
+
+    // Split addresses on ethereum / dids
+    addressArray.forEach(address => {
+      if (isSupportedDID(address)) {
+        req.didList.push(address)
+      } else {
+        req.addressList.push(address)
+      }
+    })
+
+    const url = `${opts.profileServer}/profileList`
+    return utils.fetchJson(url, req)
+  }
+
+  /**
+   * GraphQL for 3Box profile API
+   *
+   * @param     {Object}    query               A graphQL query object.
+   * @param     {Object}    opts                Optional parameters
+   * @param     {String}    opts.graphqlServer  URL of graphQL 3Box profile service
+   * @return    {Object}                        a json object with each key an address and value the profile
+   */
+  static async profileGraphQL (query, opts = {}) {
+    opts = Object.assign({ graphqlServer: GRAPHQL_SERVER_URL }, opts)
+    return graphQLRequest(opts.graphqlServer, query)
+  }
+
+  /**
+   * Verifies the proofs of social accounts that is present in the profile.
+   *
+   * @param     {Object}            profile                 A user profile object, received from the `getProfile` function
+   * @return    {Object}                                    An object containing the accounts that have been verified
+   */
+  static async getVerifiedAccounts (profile) {
+    const verifs = {}
+    try {
+      const did = await verifier.verifyDID(profile.proof_did)
+
+      verifs.did = did
+
+      if (profile.proof_github) {
+        try {
+          verifs.github = await verifier.verifyGithub(did, profile.proof_github)
+        } catch (err) {
+          // Invalid github verification
+        }
+      }
+      if (profile.proof_twitter) {
+        try {
+          verifs.twitter = await verifier.verifyTwitter(did, profile.proof_twitter)
+        } catch (err) {
+          // Invalid twitter verification
+        }
+      }
+      if (profile.ethereum_proof) {
+        try {
+          verifs.ethereum = await verifier.verifyEthereum(profile.ethereum_proof, did)
+        } catch (err) {
+          // Invalid eth verification
+        }
+      }
+    } catch (err) {
+      // Invalid proof for DID return an empty profile
+    }
+    return verifs
+  }
 }
 
-module.exports = { profileGraphQL, getProfile, getSpace, listSpaces, getThread, getThreadByAddress, getConfig, getRootStoreAddress, getProfiles, getVerifiedAccounts, getSpaceDID }
+module.exports = BoxApi


### PR DESCRIPTION
This PR makes the `api.js` module in to a class called `BoxApi`. The main `Box` class of `3box.js` now extends this class. This makes the code in `3box.js` less cluttered.