### PR TITLE
fix(ghost): add postId to ghost posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "3box",
-  "version": "1.13.2",
+  "version": "1.14.1-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4326,6 +4326,16 @@
             "idb-readable-stream": "0.0.4",
             "ltgt": "^2.1.2",
             "xtend": "^4.0.1"
+          },
+          "dependencies": {
+            "idb-readable-stream": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/idb-readable-stream/-/idb-readable-stream-0.0.4.tgz",
+              "integrity": "sha1-MoPaZkW/ayINxhumHfYr7l2uSs8=",
+              "requires": {
+                "xtend": "^4.0.1"
+              }
+            }
           }
         }
       }
@@ -8352,14 +8362,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "idb-readable-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/idb-readable-stream/-/idb-readable-stream-0.0.4.tgz",
-      "integrity": "sha1-MoPaZkW/ayINxhumHfYr7l2uSs8=",
-      "requires": {
-        "xtend": "^4.0.1"
-      }
-    },
     "identity-wallet": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/identity-wallet/-/identity-wallet-1.0.0-beta.2.tgz",
@@ -9158,6 +9160,10 @@
                 "murmurhash3js": "^3.0.1",
                 "nodeify": "^1.0.1"
               }
+            },
+            "webcrypto-shim": {
+              "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+              "from": "github:dignifiedquire/webcrypto-shim#master"
             }
           }
         },
@@ -9250,6 +9256,12 @@
                 "rsa-pem-to-jwk": "^1.1.3",
                 "tweetnacl": "^1.0.0",
                 "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+              },
+              "dependencies": {
+                "webcrypto-shim": {
+                  "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+                  "from": "github:dignifiedquire/webcrypto-shim#master"
+                }
               }
             },
             "multiaddr": {
@@ -18311,10 +18323,6 @@
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
       }
-    },
-    "webcrypto-shim": {
-      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-      "from": "github:dignifiedquire/webcrypto-shim#master"
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3box",
-  "version": "1.14.0",
+  "version": "1.14.1-beta.1",
   "description": "Interact with user data",
   "main": "lib/3box.js",
   "directories": {

--- a/src/__tests__/ghost.test.js
+++ b/src/__tests__/ghost.test.js
@@ -87,8 +87,9 @@ describe('Ghost Chat', () => {
           expect(message).toEqual('wide')
           const posts = await chat2.getPosts()
           const post = posts.pop()
-          delete post.timestamp // since we have no way to get it from onUpdate
-          expect(post).toEqual({ type: 'chat', author: DID1, message: 'wide' })
+          expect(post).toMatchObject({ type: 'chat', author: DID1, message: 'wide' })
+          expect(post).toHaveProperty('postId')
+          expect(post).toHaveProperty('timestamp')
           done()
         }
       })
@@ -102,8 +103,9 @@ describe('Ghost Chat', () => {
           expect(message).toEqual('direct peer')
           const posts = await chat2.getPosts()
           const post = posts.pop()
-          delete post.timestamp // since we have no way to get it from onUpdate
-          expect(post).toEqual({ type: 'chat', author: DID1, message: 'direct peer' })
+          expect(post).toMatchObject({ type: 'chat', author: DID1, message: 'direct peer' })
+          expect(post).toHaveProperty('postId')
+          expect(post).toHaveProperty('timestamp')
           done()
         }
       })
@@ -117,8 +119,9 @@ describe('Ghost Chat', () => {
           expect(message).toEqual('direct 3id')
           const posts = await chat2.getPosts()
           const post = posts.pop()
-          delete post.timestamp // since we have no way to get it from onUpdate
-          expect(post).toEqual({ type: 'chat', author: DID1, message: 'direct 3id' })
+          expect(post).toMatchObject({ type: 'chat', author: DID1, message: 'direct 3id' })
+          expect(post).toHaveProperty('postId')
+          expect(post).toHaveProperty('timestamp')
           done()
         }
       })
@@ -138,6 +141,7 @@ describe('Ghost Chat', () => {
     })
 
     afterAll(async () => {
+      await chat2.close()
       await utils.stopIPFS(ipfs2, 12)
     })
   })
@@ -188,11 +192,13 @@ describe('Ghost Chat', () => {
     })
 
     afterAll(async () => {
+      await chat3.close()
       await utils.stopIPFS(ipfs3, 12)
     })
   })
 
   afterAll(async () => {
+    await chat1.close()
     await utils.stopIPFS(ipfs, 11)
   })
 })


### PR DESCRIPTION
Main consideration here is that not posts are actually saved as ipfs objects. I considered just calculating the hash of the object and not storing it locally. However, this might cause confusion if anyone tries to fetch a post using the postId. This should be handled by the ipfs GC in the future.

Also removed the errors from the ghost tests :) 