### PR TITLE
fix(ghost): fixed bug when opening ghost thread while not authenticated

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -8,8 +8,8 @@
   </head>
 
   <body>
-    <!-- Open Box -->
-    <button id="bopen" type="button" class="btn btn-primary" style="margin: 50px 100px;">Open 3box</button>
+    <!-- Auth Box -->
+    <button id="bauth" type="button" class="btn btn-primary" style="margin: 50px 100px;" disabled=true>Auth 3box</button>
 
     <div id="controlls" style="display: none; padding: 5px 100px;">
 
@@ -97,51 +97,54 @@
             <span id="spaceDataPriv"></span>
           </p>
 
-          <h3> Threads: </h3>
-          <input type="text" id="threadName" placeholder="Name or Address"></br>
-          <input type="text" id="threadfirstModerator" placeholder="Thread Root Moderator"></br>
-            <span > Members Only Thread </span>
-          <input type="radio" name="members" id='members' value="true"> </br>
-            <span > Ghost ? </span>
-          <input type="radio" name="ghostCheck" id='ghostCheck' value="true"> </br>
-          <button id="joinThread" type="button" class="btn btn btn-primary" >Join thread</button>  </br></br>
-
-          <div id="threadModeration" style="display: none;">
-            <input type="text" id="threadMod" placeholder="Thread Moderator">
-            <button id="addThreadMod" type="button" class="btn btn btn-primary" >Add Thread Moderator</button></br>
-            <h5> Moderators: </h5>
-            <p>
-              <span id="threadModeratorList"></span>
-            </p>
-          </div>
-          <div id="threadMembers" style="display: none;">
-            <input type="text" id="threadMember" placeholder="Thread Member">
-            <button id="addThreadMember" type="button" class="btn btn btn-primary" >Add Thread Member</button></br>
-            <h5> Members: </h5>
-            <p>
-              <span id="threadMemberList"></span>
-            </p>
-          </div></br>
-
-          <p>
-            <span id="threadACError"></span>
-          </p>
-
-          <div id="posts" style="display: none;">
-            <h4> Posts: </h4>
-            <p>
-              <span id="threadData"></span>
-            </p>
-            <input type="text" id="postMsg" placeholder="Type your message">
-            <button id="postThread" type="button" class="btn btn btn-primary">Post</button>
-          </div>
-
         </div>
       </div>
 
       <!-- Logout -->
       <div style="padding: 25px 0px;">
         <button id="bclose" type="button" class="btn btn-primary">Logout from 3box</button>
+      </div>
+    </div>
+
+    <div style="padding: 0px 0px 25px 100px;">
+      <h3> Threads: </h3>
+      <input type="text" id="threadName" placeholder="Name of thread"></br>
+      <input type="text" id="threadSpaceName" placeholder="Space name"></br>
+      <input type="text" id="threadfirstModerator" placeholder="Thread Root Moderator"></br>
+        <span > Members Only Thread </span>
+      <input type="radio" name="members" id='members' value="true"> </br>
+        <span > Ghost ? </span>
+      <input type="radio" name="ghostCheck" id='ghostCheck' value="true"> </br>
+      <button id="openThread" type="button" class="btn btn btn-primary" disabled=true>Open thread</button>  </br></br>
+
+      <div id="threadModeration" style="display: none;">
+        <input type="text" id="threadMod" placeholder="Thread Moderator">
+        <button id="addThreadMod" type="button" class="btn btn btn-primary" >Add Thread Moderator</button></br>
+        <h5> Moderators: </h5>
+        <p>
+          <span id="threadModeratorList"></span>
+        </p>
+      </div>
+      <div id="threadMembers" style="display: none;">
+        <input type="text" id="threadMember" placeholder="Thread Member">
+        <button id="addThreadMember" type="button" class="btn btn btn-primary" >Add Thread Member</button></br>
+        <h5> Members: </h5>
+        <p>
+          <span id="threadMemberList"></span>
+        </p>
+      </div></br>
+
+      <p>
+        <span id="threadACError"></span>
+      </p>
+
+      <div id="posts" style="display: none;">
+        <h4> Posts: </h4>
+        <p>
+          <span id="threadData"></span>
+        </p>
+        <input type="text" id="postMsg" placeholder="Type your message">
+        <button id="postThread" type="button" class="btn btn btn-primary">Post</button>
       </div>
     </div>
 

--- a/example/index.js
+++ b/example/index.js
@@ -2,13 +2,19 @@ const syncComplete = (res) => {
   console.log('Sync Complete')
   updateProfileData(window.box)
 }
-bopen.addEventListener('click', event => {
+
+Box.create(window.ethereum).then(box => {
+  window.box = box
+  bauth.disabled = false
+  openThread.disabled = false
+})
+
+bauth.addEventListener('click', event => {
 
   window.ethereum.enable().then(addresses => {
-    window.Box.openBox(addresses[0],  window.ethereum, {}).then(box => {
+    window.box.auth([], { address: addresses[0] }).then(() => {
       box.onSyncDone(syncComplete)
-      window.box = box
-      console.log(box)
+      console.log('authed')
 
       controlls.style.display = 'block'
       updateProfileData(box)
@@ -95,104 +101,105 @@ bopen.addEventListener('click', event => {
           })
         })
       }
+    })
 
-      joinThread.addEventListener('click', () => {
-        const name = threadName.value
-        const firstModerator = threadfirstModerator.value
-        const membersBool = members.checked
-        const ghostBool = ghostCheck.checked
-        console.log('ghost?', ghostBool);
-        posts.style.display = 'block'
-        threadModeration.style.display = 'block'
-        if (members.checked) threadMembers.style.display = 'block'
-        if (ghostCheck.checked) {
-          addThreadMod.disabled = true
-        }
-        box.spaces[window.currentSpace].joinThread(name, {firstModerator, members: membersBool, ghost: ghostBool}).then(thread => {
-          window.currentThread = thread
-          thread.onUpdate(() => {
-            updateThreadData()
-          })
-          thread.onNewCapabilities(() => {
-            updateThreadCapabilities()
-          })
-          if (window.currentThread._room == undefined) {
-            updateThreadData()
-            updateThreadCapabilities()
-          }
-        }).catch(updateThreadError)
-      })
-
-      addThreadMod.addEventListener('click', () => {
-        const id = threadMod.value
-        window.currentThread.addModerator(id).then(res => {
-          updateThreadCapabilities()
-        }).catch(updateThreadError)
-      })
-
-      addThreadMember.addEventListener('click', () => {
-        const id = threadMember.value
-        window.currentThread.addMember(id).then(res => {
-          updateThreadCapabilities()
-        }).catch(updateThreadError)
-      })
-
-      window.deletePost = (el) => {
-        window.currentThread.deletePost(el.id).then(res => {
-          updateThreadData()
-        }).catch(updateThreadError)
-      }
-
-      const updateThreadError = (e = '') => {
-        threadACError.innerHTML = e
-      }
-
-      const updateThreadData = () => {
-        threadData.innerHTML = ''
-        updateThreadError()
-        window.currentThread.getPosts().then(posts => {
-          posts.map(post => {
-            threadData.innerHTML += post.author + ': <br />' + post.message  + '<br /><br />'
-            threadData.innerHTML += `<button id="` + post.postId + `"onClick="window.deletePost(` + post.postId + `)" type="button" class="btn btn btn-primary" >Delete</button>` + '<br /><br />'
-          })
-        })
-      }
-
-      const updateThreadCapabilities = () => {
-        threadMemberList.innerHTML = ''
-        // if else statement cause ghost thread can't list moderators
-        if (window.currentThread._peerId) {
-          window.currentThread.listMembers().then(members => {
-            members.map(member => {
-                threadMemberList.innerHTML += member + '<br />'
-            })
-          })
-        } else {
-          if (window.currentThread._members) {
-            window.currentThread.listMembers().then(members => {
-              members.map(member => {
-                  threadMemberList.innerHTML += member + '<br />'
-              })
-            })
-          }
-          threadModeratorList.innerHTML = ''
-          window.currentThread.listModerators().then(moderators => {
-            moderators.map(moderator => {
-                threadModeratorList.innerHTML += moderator  +  '<br />'
-            })
-          })
-        }
-      }
-
-      postThread.addEventListener('click', () => {
-        window.currentThread.post(postMsg.value).catch(updateThreadError)
-      })
-
-      bclose.addEventListener('click', () => {
-        logout(box)
-      })
+    bclose.addEventListener('click', () => {
+      logout(box)
     })
   })
+})
+
+openThread.addEventListener('click', () => {
+  const name = threadName.value
+  const space = threadSpaceName.value
+  const firstModerator = threadfirstModerator.value
+  const membersBool = members.checked
+  const ghostBool = ghostCheck.checked
+  console.log('ghost?', ghostBool);
+  posts.style.display = 'block'
+  threadModeration.style.display = 'block'
+  if (members.checked) threadMembers.style.display = 'block'
+  if (ghostCheck.checked) {
+    addThreadMod.disabled = true
+  }
+  box.openThread(space, name, {firstModerator, members: membersBool, ghost: ghostBool}).then(thread => {
+    window.currentThread = thread
+    thread.onUpdate(() => {
+      updateThreadData()
+    })
+    thread.onNewCapabilities(() => {
+      updateThreadCapabilities()
+    })
+    if (window.currentThread._room == undefined) {
+      updateThreadData()
+      updateThreadCapabilities()
+    }
+  }).catch(updateThreadError)
+})
+
+addThreadMod.addEventListener('click', () => {
+  const id = threadMod.value
+  window.currentThread.addModerator(id).then(res => {
+    updateThreadCapabilities()
+  }).catch(updateThreadError)
+})
+
+addThreadMember.addEventListener('click', () => {
+  const id = threadMember.value
+  window.currentThread.addMember(id).then(res => {
+    updateThreadCapabilities()
+  }).catch(updateThreadError)
+})
+
+window.deletePost = (el) => {
+  window.currentThread.deletePost(el.id).then(res => {
+    updateThreadData()
+  }).catch(updateThreadError)
+}
+
+const updateThreadError = (e = '') => {
+  threadACError.innerHTML = e
+}
+
+const updateThreadData = () => {
+  threadData.innerHTML = ''
+  updateThreadError()
+  window.currentThread.getPosts().then(posts => {
+    posts.map(post => {
+      threadData.innerHTML += post.author + ': <br />' + post.message  + '<br /><br />'
+      threadData.innerHTML += `<button id="` + post.postId + `"onClick="window.deletePost(` + post.postId + `)" type="button" class="btn btn btn-primary" >Delete</button>` + '<br /><br />'
+    })
+  })
+}
+
+const updateThreadCapabilities = () => {
+  threadMemberList.innerHTML = ''
+  // if else statement cause ghost thread can't list moderators
+  if (window.currentThread._peerId) {
+    window.currentThread.listMembers().then(members => {
+      members.map(member => {
+          threadMemberList.innerHTML += member + '<br />'
+      })
+    })
+  } else {
+    if (window.currentThread._members) {
+      window.currentThread.listMembers().then(members => {
+        members.map(member => {
+            threadMemberList.innerHTML += member + '<br />'
+        })
+      })
+    }
+    threadModeratorList.innerHTML = ''
+    window.currentThread.listModerators().then(moderators => {
+      moderators.map(moderator => {
+          threadModeratorList.innerHTML += moderator  +  '<br />'
+      })
+    })
+  }
+}
+
+postThread.addEventListener('click', () => {
+  window.currentThread.post(postMsg.value).catch(updateThreadError)
 })
 
 getProfile.addEventListener('click', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "3box",
-  "version": "1.15.0",
+  "version": "1.16.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8402,9 +8402,9 @@
       }
     },
     "identity-wallet": {
-      "version": "1.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/identity-wallet/-/identity-wallet-1.1.0-beta.1.tgz",
-      "integrity": "sha512-icn2Yc7v87bzs+S2XZzur8XHihICLxre+26bB+gHn1aWy/dQERXG2bPtmuDKb2U4K1DRqSNirtQzxHQoTnBPaw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/identity-wallet/-/identity-wallet-1.1.0.tgz",
+      "integrity": "sha512-D6zGznRc3ba+MO916mUDYZcFHBwScHBm0qIopMHZvUvKgRWrHr7A/19xBV6G5BNe3rSIa9TzMeeLCm3qR1i6Ag==",
       "dev": true,
       "requires": {
         "3id-blockchain-utils": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3box",
-  "version": "1.15.0",
+  "version": "1.16.0-beta.2",
   "description": "Interact with user data",
   "main": "lib/3box.js",
   "directories": {
@@ -77,7 +77,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "^8.0.6",
     "express": "^4.17.0",
-    "identity-wallet": "^1.1.0-beta.1",
+    "identity-wallet": "^1.1.0",
     "jest": "^23.6.0",
     "jsdoc-to-markdown": "^5.0.0",
     "standard": "^14.3.1",

--- a/src/3box.js
+++ b/src/3box.js
@@ -149,11 +149,11 @@ class Box extends BoxApi {
       await this._3id.authenticate(spaces)
     }
     // make sure we are authenticated to threads
-    spaces.forEach(space => {
+    await Promise.all(spaces.map(async space => {
       if (this.spaces[space]) {
-        this.spaces[space]._authThreads(this._3id)
+        await this.spaces[space]._authThreads(this._3id)
       }
-    })
+    }))
   }
 
   /**

--- a/src/ghost.js
+++ b/src/ghost.js
@@ -20,7 +20,19 @@ class GhostThread extends EventEmitter {
     this._filters = opts.ghostFilters || []
 
     this._room.on('message', async ({ from, data }) => {
-      const { payload, issuer } = await this._verifyData(data)
+      let payload, issuer
+      if (data.toString().startsWith('{')) {
+        // we got a non signed message (can only be backlog request, or response)
+        payload = JSON.parse(data)
+        if (payload.type !== 'request_backlog' && payload.type !== 'backlog_response') {
+          // join and messages need signatures
+          return
+        }
+      } else {
+        const verified = await this._verifyData(data)
+        payload = verified.payload
+        issuer = verified.issuer
+      }
 
       // we pass the payload, issuer and peerID (from) to each filter in our filters array and reduce the value to a single boolean
       // this boolean indicates whether the message passed the filters
@@ -33,7 +45,7 @@ class GhostThread extends EventEmitter {
             break
           case 'request_backlog':
             this.getPosts(this._backlogLimit)
-              .then(posts => this._sendDirect({ type: 'backlog_response', message: posts }, from))
+              .then(posts => this._sendDirect({ type: 'backlog_response', message: posts }, from, true))
             break
           case 'backlog_response':
             payload.message.map(msg => {
@@ -59,6 +71,12 @@ class GhostThread extends EventEmitter {
 
   _set3id (threeId) {
     this._3id = threeId
+    // announce to other peers that we are online
+    this.listMembers().then(members => {
+      members.map(({ id }) => {
+        this._announce(this._threeIdToPeerId(id))
+      })
+    })
   }
 
   /**
@@ -100,8 +118,11 @@ class GhostThread extends EventEmitter {
    * @param     {String}      to              The PeerID of a user (optional)
    */
   async _announce (to) {
-    !to ? await this._broadcast({ type: 'join' })
-      : await this._sendDirect({ type: 'join' }, to)
+    if (this._3id) {
+      // we don't announce presence if we're not authed
+      !to ? await this._broadcast({ type: 'join' })
+        : await this._sendDirect({ type: 'join' }, to)
+    }
   }
 
   /**
@@ -138,7 +159,7 @@ class GhostThread extends EventEmitter {
    */
   async _requestBacklog (to) {
     !to ? await this._broadcast({ type: 'request_backlog' })
-      : await this._sendDirect({ type: 'request_backlog' }, to)
+      : await this._sendDirect({ type: 'request_backlog' }, to, true)
   }
 
   /**
@@ -154,10 +175,10 @@ class GhostThread extends EventEmitter {
    *
    * @param     {Object}    message                 The message
    */
-  async _broadcast (message) {
-    if (!this._3id) throw new Error('Can not send message if not authenticated')
-    const jwt = await this._3id.signJWT(message)
-    this._room.broadcast(jwt)
+  async _broadcast (message, noSignature) {
+    if (!this._3id ? !noSignature : false) throw new Error('Can not send message if not authenticated')
+    const payload = noSignature ? JSON.stringify(message) : await this._3id.signJWT(message)
+    this._room.broadcast(payload)
   }
 
   /**
@@ -166,11 +187,11 @@ class GhostThread extends EventEmitter {
    * @param     {Object}    message             The message
    * @param     {String}    to                  The PeerID or 3ID of the receiver
    */
-  async _sendDirect (message, to) {
-    if (!this._3id) throw new Error('Can not send message if not authenticated')
-    const jwt = await this._3id.signJWT(message)
-    to.startsWith('Qm') ? this._room.sendTo(to, jwt)
-      : this._room.sendTo(this._threeIdToPeerId(to), jwt)
+  async _sendDirect (message, to, noSignature) {
+    if (!this._3id ? !noSignature : false) throw new Error('Can not send message if not authenticated')
+    const payload = noSignature ? JSON.stringify(message) : await this._3id.signJWT(message)
+    to.startsWith('Qm') ? this._room.sendTo(to, payload)
+      : this._room.sendTo(this._threeIdToPeerId(to), payload)
   }
 
   /**

--- a/src/space.js
+++ b/src/space.js
@@ -149,7 +149,7 @@ class Space {
     const odbIdentity = await threeId.getOdbId(this._name)
     Object.values(this._activeThreads).forEach(thread => {
       if (thread.isGhost) {
-        thread._set3id(this._3id)
+        thread._set3id(threeId)
       } else {
         thread._setIdentity(odbIdentity)
       }


### PR DESCRIPTION
This fixes a bug where ghost threads don't work when you're not autenticated.

From discord:

 
Kenzo - 3BoxToday at 12:57 AM
@oed 3⃣ 
Now Im able to openThread which is really cool but there seem to be a few issues. The returned thread from openThread should be the same as the thread that was returned the original way via joinThread correct?

Im doing 
    const box = await Box.create(ethereum);
    const thread = await box.openThread(spaceName, threadName, { ghost: true });

    this.setState({ thread, threadJoined: true, }, async () => {
      await this.updateComments();
      await this.updateMembersOnline();

      thread.onUpdate(() => this.updateComments());
      thread.onNewCapabilities(() => this.updateMembersOnline());
    });
 
which is exactly how I was fetching comments the original way, though now it doesnt return any comments.

The original way would fetch comments when onUpdate (so on the second time calling updateComments) - in the new way, the thread does not update (onUpdate doesnt trigger)

On top of this, getting a weird error saying Can not send message if not authenticated, even though there was no attempt to send a message