### PR TITLE
fix(verifier): Verify legacy muport DID properly

### DIFF
--- a/src/utils/verifier.js
+++ b/src/utils/verifier.js
@@ -116,7 +116,7 @@ module.exports = {
     const muport = verified.payload.muport
     const res = {}
     if (muport) {
-      const muportDID = await didJWT.verifyJWT(muport).payload.iss
+      const muportDID = (await didJWT.verifyJWT(muport)).payload.iss
       res.muport = muportDID
     }
     res.did = verified.payload.iss


### PR DESCRIPTION
Fixes bug where if you had a muport DID in your 3ID verification the `Box.getVerifiedAccounts` broke.