### PR TITLE
ref: link address directly on auth

### DIFF
--- a/src/3box.js
+++ b/src/3box.js
@@ -93,7 +93,7 @@ class Box extends BoxApi {
     })
     this._3id.startUpdatePolling()
 
-    this.public = new PublicStore(this._3id.muportFingerprint + '.public', this._linkProfile.bind(this), this.replicator, this._3id)
+    this.public = new PublicStore(this._3id.muportFingerprint + '.public', this.replicator, this._3id)
     this.private = new PrivateStore(this._3id.muportFingerprint + '.private', this.replicator, this._3id)
     await this.public._load()
     await this.private._load()
@@ -154,6 +154,8 @@ class Box extends BoxApi {
       }
       await this._3id.authenticate(spaces, { address: opts.address })
     }
+    // Link address if needed
+    await this.linkAddress()
     // make sure we are authenticated to threads
     await Promise.all(spaces.map(async space => {
       if (this.spaces[space]) {
@@ -201,7 +203,6 @@ class Box extends BoxApi {
     if (!this.spaces[name].isOpen) {
       try {
         await this.spaces[name].open(this._3id, opts)
-        if (!await this.isAddressLinked()) this.linkAddress()
       } catch (e) {
         delete this.spaces[name]
         if (e.message.includes('User denied message signature.')) {
@@ -434,11 +435,11 @@ class Box extends BoxApi {
       const issuer = didJWT.decodeJWT(proofdid).payload.iss
       if (issuer.includes('muport')) {
         const jwt = { muport: proofdid }
-        await this.public.set('proof_did', await this._3id.signJWT(jwt), { noLink: true })
+        await this.public.set('proof_did', await this._3id.signJWT(jwt))
       }
     } else {
       // we can just sign an empty JWT as a proof that we own this DID
-      await this.public.set('proof_did', await this._3id.signJWT(), { noLink: true })
+      await this.public.set('proof_did', await this._3id.signJWT())
     }
   }
 

--- a/src/__tests__/__snapshots__/3box.test.js.snap
+++ b/src/__tests__/__snapshots__/3box.test.js.snap
@@ -1,5 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`3Box should handle error and not link profile on first call to _linkProfile 1`] = `[Error: An error occured while publishing link:]`;
-
-exports[`3Box should not call createLink if ethereum_proof in rootStore on call to _linkProfile 1`] = `[Error: An error occured while publishing link:]`;

--- a/src/__tests__/publicStore.test.js
+++ b/src/__tests__/publicStore.test.js
@@ -7,30 +7,19 @@ jest.mock('../keyValueStore')
 
 describe('PublicStore', () => {
   let publicStore
-  const linkProfile = jest.fn()
 
   beforeAll(async () => {
-    publicStore = new PublicStore(STORE_NAME, linkProfile, replicatorMock)
+    publicStore = new PublicStore(STORE_NAME, replicatorMock)
   })
 
   it('should throw if not synced', async () => {
     expect(publicStore.all('key', 'value')).rejects.toThrow(/_load must/)
   })
 
-  it('should call linkProfile when set is called', async () => {
+  it('should set data correctly', async () => {
     await publicStore._load()
     let ret = await publicStore.set('key1', 'value1')
     expect(ret).toEqual(true)
-    expect(linkProfile).toHaveBeenCalledTimes(1)
-    expect(linkProfile).toHaveBeenCalledWith()
-  })
-
-  it('should not call linkProfile when noLink is true', async () => {
-    linkProfile.mockClear()
-    await publicStore._load()
-    let ret = await publicStore.set('key1', 'value1', { noLink: true })
-    expect(ret).toEqual(true)
-    expect(linkProfile).toHaveBeenCalledTimes(0)
   })
 
   it('should throw if key not given', async () => {

--- a/src/publicStore.js
+++ b/src/publicStore.js
@@ -2,21 +2,13 @@ const KeyValueStore = require('./keyValueStore')
 const { throwIfUndefined, throwIfNotEqualLenArrays } = require('./utils/index')
 
 class ProfileStore extends KeyValueStore {
-  constructor (name, linkProfile, replicator, threeId) {
-    super(name, replicator, threeId)
-    this._linkProfile = linkProfile
-  }
-
-  async set (key, value, opts = {}) {
+  async set (key, value) {
     throwIfUndefined(key, 'key')
-    // if this is the noLink call we shouldn't call _linkProfile.
-    if (!opts.noLink) await this._linkProfile()
     return super.set(key, value)
   }
 
   async setMultiple (keys, values) {
     throwIfNotEqualLenArrays(keys, values)
-    await this._linkProfile()
     return super.setMultiple(keys, values)
   }
 }


### PR DESCRIPTION
This PR improves UX by prompting the user to sign the account link message when authenticating if it has not already happened. Before this only happened once you opened a space or added data to the public store. 

This makes the code cleaner and easier to work with while improving stability.