### PR TITLE
Fix/subdids on auth

### DIFF
--- a/src/3box.js
+++ b/src/3box.js
@@ -158,9 +158,7 @@ class Box extends BoxApi {
     await this.linkAddress()
     // make sure we are authenticated to threads
     await Promise.all(spaces.map(async space => {
-      if (this.spaces[space]) {
-        await this.spaces[space]._authThreads(this._3id)
-      }
+      await this.openSpace(space)
     }))
   }
 

--- a/src/__tests__/3box.test.js
+++ b/src/__tests__/3box.test.js
@@ -282,6 +282,7 @@ describe('3Box', () => {
     const opts = { address: '0x12345' }
     const box = await Box.create(prov, boxOpts)
     await box.openThread(space, name, {})
+    expect(box.spaces[space].isOpen).toEqual(false)
 
     await box.auth([space], opts)
     expect(mocked3id.getIdFromEthAddress).toHaveBeenCalledTimes(1)
@@ -295,7 +296,7 @@ describe('3Box', () => {
     expect(box.public._load).toHaveBeenCalledWith()
     expect(box.private._load).toHaveBeenCalledTimes(1)
     expect(box.private._load).toHaveBeenCalledWith()
-    expect(box.spaces[space]._authThreads).toHaveBeenCalledTimes(1)
+    expect(box.spaces[space].isOpen).toEqual(true)
     await box.syncDone
     expect(mockedUtils.fetchJson).toHaveBeenCalledTimes(3)
     expect(mockedUtils.fetchJson.mock.calls[1][0]).toEqual('address-server/odbAddress')


### PR DESCRIPTION
There was an issue before when using the auth metod to authenticate to spaces where the subDIDs for each space wouldn't get published to the rootstore. This caused issues with threads. This fixes that by simply opening the space internally.

Based on #798, to be refactored.