### PR TITLE
chore: bump libp2p-webrtc-star

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3302,9 +3302,9 @@
       }
     },
     "@types/istanbul-lib-coverage": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.2.tgz",
-      "integrity": "sha512-rsZg7eL+Xcxsxk2XlBt9KcG8nOp9iYdKCOikY9x2RFJCyOdNj4MKPQty0e8oZr29vVAzKXr1BmR+kZauti3o1w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
       "dev": true
     },
     "@types/istanbul-lib-report": {
@@ -3327,9 +3327,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
-      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
       "dev": true
     },
     "@types/node": {
@@ -3702,9 +3702,9 @@
       }
     },
     "acorn": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
       "dev": true
     },
     "acorn-globals": {
@@ -6020,9 +6020,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001079",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001079.tgz",
-      "integrity": "sha512-2KaYheg0iOY+CMmDuAB3DHehrXhhb4OZU4KBVGDr/YKyYAcpudaiUQ9PJ9rxrPlKEoJ3ATasQ5AN48MqpwS43Q==",
+      "version": "1.0.30001081",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001081.tgz",
+      "integrity": "sha512-iZdh3lu09jsUtLE6Bp8NAbJskco4Y3UDtkR3GTCJGsbMowBU5IWDFF79sV2ws7lSqTzWyKazxam2thasHymENQ==",
       "dev": true
     },
     "capture-exit": {
@@ -6904,18 +6904,18 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "interface-datastore": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.2.tgz",
-          "integrity": "sha512-6pgs0z8VLTxcyRsT2O0nT87s7VOPs7MAzAqNhYsgpR+DPokyU5BCGD4DDEQmqORewMb4eV4HmwopW5UlkvYk9w==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
+          "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
           "requires": {
             "buffer": "^5.5.0",
             "class-is": "^1.1.0",
-            "err-code": "^2.0.0",
+            "err-code": "^2.0.1",
             "ipfs-utils": "^2.2.2",
             "iso-random-stream": "^1.1.1",
             "it-all": "^1.0.2",
@@ -6938,18 +6938,18 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "interface-datastore": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.2.tgz",
-          "integrity": "sha512-6pgs0z8VLTxcyRsT2O0nT87s7VOPs7MAzAqNhYsgpR+DPokyU5BCGD4DDEQmqORewMb4eV4HmwopW5UlkvYk9w==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
+          "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
           "requires": {
             "buffer": "^5.5.0",
             "class-is": "^1.1.0",
-            "err-code": "^2.0.0",
+            "err-code": "^2.0.1",
             "ipfs-utils": "^2.2.2",
             "iso-random-stream": "^1.1.1",
             "it-all": "^1.0.2",
@@ -6975,18 +6975,18 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "interface-datastore": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.2.tgz",
-          "integrity": "sha512-6pgs0z8VLTxcyRsT2O0nT87s7VOPs7MAzAqNhYsgpR+DPokyU5BCGD4DDEQmqORewMb4eV4HmwopW5UlkvYk9w==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
+          "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
           "requires": {
             "buffer": "^5.5.0",
             "class-is": "^1.1.0",
-            "err-code": "^2.0.0",
+            "err-code": "^2.0.1",
             "ipfs-utils": "^2.2.2",
             "iso-random-stream": "^1.1.1",
             "it-all": "^1.0.2",
@@ -7007,18 +7007,18 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "interface-datastore": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.2.tgz",
-          "integrity": "sha512-6pgs0z8VLTxcyRsT2O0nT87s7VOPs7MAzAqNhYsgpR+DPokyU5BCGD4DDEQmqORewMb4eV4HmwopW5UlkvYk9w==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
+          "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
           "requires": {
             "buffer": "^5.5.0",
             "class-is": "^1.1.0",
-            "err-code": "^2.0.0",
+            "err-code": "^2.0.1",
             "ipfs-utils": "^2.2.2",
             "iso-random-stream": "^1.1.1",
             "it-all": "^1.0.2",
@@ -7041,18 +7041,18 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "interface-datastore": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.2.tgz",
-          "integrity": "sha512-6pgs0z8VLTxcyRsT2O0nT87s7VOPs7MAzAqNhYsgpR+DPokyU5BCGD4DDEQmqORewMb4eV4HmwopW5UlkvYk9w==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
+          "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
           "requires": {
             "buffer": "^5.5.0",
             "class-is": "^1.1.0",
-            "err-code": "^2.0.0",
+            "err-code": "^2.0.1",
             "ipfs-utils": "^2.2.2",
             "iso-random-stream": "^1.1.1",
             "it-all": "^1.0.2",
@@ -7586,9 +7586,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.465",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.465.tgz",
-      "integrity": "sha512-K/lUeT3NLAsJ5SHRDhK3/zd0tw7OUllYD8w+fTOXm6ljCPsp2qq+vMzxpLo8u1M27ZjZAjRbsA6rirvne2nAMQ==",
+      "version": "1.3.467",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.467.tgz",
+      "integrity": "sha512-U+QgsL8TZDU/n+rDnYDa3hY5uy3C4iry9mrJS0PNBBGwnocuQ+aHSfgY44mdlaK9744X5YqrrGUvD9PxCLY1HA==",
       "dev": true
     },
     "elliptic": {
@@ -12003,9 +12003,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "ipfs-utils": {
           "version": "1.2.4",
@@ -12217,9 +12217,9 @@
           }
         },
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -12309,9 +12309,9 @@
           }
         },
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -12352,9 +12352,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         }
       }
     },
@@ -12524,9 +12524,9 @@
           }
         },
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         }
       }
     },
@@ -12713,9 +12713,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         }
       }
     },
@@ -12746,9 +12746,9 @@
           }
         },
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -12791,9 +12791,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -12816,18 +12816,18 @@
       }
     },
     "ipfs-utils": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.2.2.tgz",
-      "integrity": "sha512-Urn88nHGtCWwF9J4+f3ztBTEdXK9kiyg/bq2l4zhMn1BZhsNQZiJeP4HP+dxl8TSOIbRDebu8WatX9w2t/46mg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.3.0.tgz",
+      "integrity": "sha512-kM8q/h50ufM1i+vgxHsIU7afURBPWDRIO3hu4eTCp9yq/3YuxKmhiNeBDecnohOXHweN0bdWspPg89sVgrxlyQ==",
       "requires": {
         "abort-controller": "^3.0.0",
         "any-signal": "^1.1.0",
         "buffer": "^5.4.2",
         "err-code": "^2.0.0",
-        "fs-extra": "^9.0.0",
+        "fs-extra": "^9.0.1",
         "is-electron": "^2.2.0",
         "iso-url": "^0.4.7",
-        "it-glob": "0.0.7",
+        "it-glob": "0.0.8",
         "merge-options": "^2.0.0",
         "nanoid": "^3.1.3",
         "node-fetch": "^2.6.0",
@@ -12835,23 +12835,57 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
+        },
+        "it-glob": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.8.tgz",
+          "integrity": "sha512-PmIAgb64aJPM6wwT1UTlNDAJnNgdGrvr0vRr3AYCngcUuq1KaAovuz0dQAmUkaXudDG3EQzc7OttuLW9DaL3YQ==",
+          "requires": {
+            "fs-extra": "^8.1.0",
+            "minimatch": "^3.0.4"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "8.1.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+              "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+              "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            }
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         }
       }
     },
     "ipld": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.26.2.tgz",
-      "integrity": "sha512-HGBXh3kBXVGpvmuIaHYn18tBGqNmmaGv4PLgKkKuwqnn6YE/zl/EI5qrKDuPmZ1Vu07GJdacCw2+Tf/PzG3eug==",
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.26.3.tgz",
+      "integrity": "sha512-x6Udh4LVMerZduKk0eRNOhBKJeZwQgZ1YIH9AR7E5RjRJ0cPqEpq43DGbiHhU5XOXjBQiwdJwX5p9pxxiKkG9Q==",
       "requires": {
         "buffer": "^5.6.0",
         "cids": "~0.8.0",
         "ipld-block": "~0.9.1",
         "ipld-dag-cbor": "~0.15.0",
         "ipld-dag-pb": "~0.18.1",
-        "ipld-raw": "^4.0.0",
+        "ipld-raw": "^5.0.0",
         "merge-options": "^2.0.0",
         "multicodec": "^1.0.0",
         "typical": "^6.0.0"
@@ -12867,6 +12901,39 @@
             "multibase": "~0.7.0",
             "multicodec": "^1.0.1",
             "multihashes": "~0.4.17"
+          }
+        },
+        "err-code": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
+        },
+        "ipld-raw": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-5.0.0.tgz",
+          "integrity": "sha512-z1Fie224lTtQZbFg+wC5WDY692G3SIpO8vT86yCU83vqpIvasVuV3SzDSv7G36kRxP03PPZOkvKAOFrcjb7gpw==",
+          "requires": {
+            "cids": "~0.8.0",
+            "multicodec": "^1.0.1",
+            "multihashing-async": "~0.8.1"
+          }
+        },
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        },
+        "multihashing-async": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.1.tgz",
+          "integrity": "sha512-qu3eIXHebc9a4OU4n/60BdZLFpX+/dGBs3DbzXCxX1aU0rFF19KQAiGl+sRL9wvKIJdeF2+w16RRJrpyTHpkkA==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "~0.8.0",
+            "multihashes": "~0.4.15",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         }
       }
@@ -12884,9 +12951,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -12933,9 +13000,9 @@
       }
     },
     "ipld-dag-cbor": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.2.tgz",
-      "integrity": "sha512-Ioni4s959P/CtkWQOt1TXrj4zqc3MoPxvHrEmybCn5JFdG3dpBNJR1oBVvP6uUrmF5bBtUGKNbX1pSI5SEOaHg==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.3.tgz",
+      "integrity": "sha512-m23nG7ZyoVFnkK55/bLAErc7EfiMgaEQlqHWDTGzPI+O5r6bPfp+qbL5zTVSIT8tpbHmu174dwerVtLoVgeVyA==",
       "requires": {
         "borc": "^2.1.2",
         "buffer": "^5.5.0",
@@ -12958,9 +13025,9 @@
           }
         },
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -13009,9 +13076,9 @@
           }
         },
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -13050,9 +13117,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -13088,9 +13155,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -13123,9 +13190,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -13160,9 +13227,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -13202,18 +13269,18 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "interface-datastore": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.2.tgz",
-          "integrity": "sha512-6pgs0z8VLTxcyRsT2O0nT87s7VOPs7MAzAqNhYsgpR+DPokyU5BCGD4DDEQmqORewMb4eV4HmwopW5UlkvYk9w==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
+          "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
           "requires": {
             "buffer": "^5.5.0",
             "class-is": "^1.1.0",
-            "err-code": "^2.0.0",
+            "err-code": "^2.0.1",
             "ipfs-utils": "^2.2.2",
             "iso-random-stream": "^1.1.1",
             "it-all": "^1.0.2",
@@ -16300,9 +16367,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -16515,9 +16582,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "p-map": {
           "version": "4.0.0",
@@ -16557,9 +16624,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         }
       }
     },
@@ -16613,9 +16680,9 @@
           }
         },
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -16680,12 +16747,12 @@
       }
     },
     "libp2p-keychain": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/libp2p-keychain/-/libp2p-keychain-0.6.0.tgz",
-      "integrity": "sha512-r0EmaRvEwOImiYxrhTAjxzFf+JHxk66ooMezHF/LkXIdncc/eGt32k80UvnJ/xgoCzDHl4IlzXu1j8VKxy/80g==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/libp2p-keychain/-/libp2p-keychain-0.6.1.tgz",
+      "integrity": "sha512-7K7MZ4KHQVtudAatPnJ2eWI0NvnXxtdEnp3+AXdiDd4/DmwF4wLu+XJ0PR9EQpnsMNu8tIgsNUIA8bmDyUU5iw==",
       "requires": {
         "err-code": "^2.0.0",
-        "interface-datastore": "^0.8.0",
+        "interface-datastore": "^1.0.2",
         "libp2p-crypto": "^0.17.1",
         "merge-options": "^2.0.0",
         "node-forge": "^0.9.1",
@@ -16693,9 +16760,24 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
+        },
+        "interface-datastore": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
+          "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "err-code": "^2.0.1",
+            "ipfs-utils": "^2.2.2",
+            "iso-random-stream": "^1.1.1",
+            "it-all": "^1.0.2",
+            "it-drain": "^1.0.1",
+            "nanoid": "^3.0.2"
+          }
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -16795,9 +16877,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -16866,9 +16948,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -16910,9 +16992,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",
@@ -16984,9 +17066,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         }
       }
     },
@@ -17003,16 +17085,16 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         }
       }
     },
     "libp2p-webrtc-star": {
-      "version": "0.17.10",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.17.10.tgz",
-      "integrity": "sha512-9kJhfeu8t33V8dqsNCV5JkUPUMaUV4mw0rhSLeq5aXLAQ0nyxyGua6XdCNxW4Pz1tDMF0H24AAiH/0bnhmvHkQ==",
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.17.11.tgz",
+      "integrity": "sha512-v0zhxhNSyqzpmUeH1LzM3VJTgvU/Fma2TlfFwtGVyB9E0DD3XhPJonrMOMxx3HVmJTeJKbEf6TLmymBUEZVYMQ==",
       "requires": {
         "@hapi/hapi": "^18.4.0",
         "@hapi/inert": "^5.2.2",
@@ -17040,9 +17122,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         }
       }
     },
@@ -17065,9 +17147,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         }
       }
     },
@@ -18025,9 +18107,9 @@
       },
       "dependencies": {
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         }
       }
     },
@@ -19463,9 +19545,9 @@
           }
         },
         "err-code": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-          "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.1.tgz",
+          "integrity": "sha512-kRoa6BXKCX1ImYDZ6yKO0ckU5af1pNV4mpILrmwXrpIiLaVYM4uyMbwhZZ2xhy7WwVm6sEPYJABX4X6jRD3Jew=="
         },
         "js-sha3": {
           "version": "0.8.0",


### PR DESCRIPTION
This Just bumps the `libp2p-webrtc-star` dependency to suppress connection errors: https://github.com/libp2p/js-libp2p/issues/662#event-3433003905