### PR TITLE
fix: use same level db path as before upgrade

### DIFF
--- a/src/3box.js
+++ b/src/3box.js
@@ -602,7 +602,7 @@ function initIPFSRepo () {
     repoOpts = { storageBackends: { root: () => levelInstance } }
   }
 
-  const repo = new IPFSRepo('ipfs', repoOpts)
+  const repo = new IPFSRepo('level-js-ipfs', repoOpts)
 
   return {
     repo,


### PR DESCRIPTION
older versions or older version of level prepended level-js- to given path 