### PR TITLE
fix: timeout links which dont resolve ipfs.dag.get

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "3box",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "orbit-db-cache": "^0.3.0",
     "orbit-db-identity-provider": "^0.3.0",
     "orbit-db-storage-adapter": "^0.5.3",
+    "p-timeout": "^3.2.0",
     "store": "^2.0.12",
     "tweetnacl": "^1.0.1",
     "tweetnacl-util": "^0.15.0"

--- a/src/replicator.js
+++ b/src/replicator.js
@@ -258,7 +258,7 @@ class Replicator {
         this.ipfs.pin.add(cid)
       } catch (e) { }
     }
-    return Promise.all(resolveLinks)
+    return resolveLinks
   }
 
   async getAuthData () {

--- a/src/replicator.js
+++ b/src/replicator.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const EventEmitter = require('events')
 const merge = require('lodash.merge')
+const pTimeout = require('p-timeout')
 const multiaddr = require('multiaddr')
 const OrbitDB = require('orbit-db')
 const Pubsub = require('orbit-db-pubsub')
@@ -247,14 +248,16 @@ class Replicator {
   async getAddressLinks () {
     const entries = await this.rootstore.iterator({ limit: -1 }).collect()
     const linkEntries = entries.filter(e => e.payload.value.type === entryTypes.ADDRESS_LINK)
-    const resolveLinks = linkEntries.map(async entry => {
+    const resolveLinks = []
+
+    for (const entry of linkEntries) {
       const cid = entry.payload.value.data
-      // TODO handle missing ipfs obj??, timeouts?
-      const obj = (await this.ipfs.dag.get(cid)).value
-      this.ipfs.pin.add(cid)
-      obj.entry = entry
-      return obj
-    })
+      try {
+        const dag = await pTimeout(this.ipfs.dag.get(cid), 2500)
+        resolveLinks.push(Object.assign(dag.value, { entry }))
+        this.ipfs.pin.add(cid)
+      } catch (e) { }
+    }
     return Promise.all(resolveLinks)
   }
 


### PR DESCRIPTION
Fix allowed one my oldest accounts to work again (from Oct 2018). One of the address-links in rootstore had a cid which was not available anywhere (ie our pinning node). This may have occurred from number of things, from switching to storing links in rootstore/ipfs, to not pinning links at one point on pinning node (i think this was bug at one point...), etc I did have a second existing link that was valid and resolved (but the other blocked this before fix). This also blocked creating new link, if an old one was not able to resolve.