### PR TITLE
fix: Use port number indicated in the documentation

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -1,7 +1,7 @@
 const express = require('express')
 const serveStatic = require('serve-static')
 const path = require('path')
-const port = 30000
+const port = 3000
 
 const app = express()
 app.use(serveStatic(path.join(__dirname), {'index': ['index.html']}))


### PR DESCRIPTION
Port number for the example app (indicated here: https://docs.3box.io/try/example-app) uses `3000`, but in the code the port number is`30000`. Either the code or the documentation will need to be changed; if it's the latter, feel free to close the PR.