### PR TITLE
Added README to example directory to help bring clarity to developers…

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,10 +1,10 @@
 ## <a name="example"></a> Example Application
 
-You can quickly run and interact with some code by looking at the files in the `/example` folder. You run the example with the following commands:
+You can quickly run and interact with the example code in this directory. You run the example with the following commands:
 
 ```bash
 $ npm ci
 $ npm run example:start
 ```
 
-This runs a simple server at `http://localhost:3000/` that serves the static `example/index.html` file. This allows it easily interact with Metamask. You can edit the `example/index.html` file to try different code.
+This runs a simple server at `http://localhost:30000/` that serves the static `example/index.html` file. This allows it easily interact with Metamask. You can edit the `example/index.html` file to try different code.

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,10 @@
+## <a name="example"></a> Example Application
+
+You can quickly run and interact with some code by looking at the files in the `/example` folder. You run the example with the following commands:
+
+```bash
+$ npm ci
+$ npm run example:start
+```
+
+This runs a simple server at `http://localhost:3000/` that serves the static `example/index.html` file. This allows it easily interact with Metamask. You can edit the `example/index.html` file to try different code.


### PR DESCRIPTION
… new to the platform that are testing functionality

For example, I went straight to the examples folder, and then tried to test the examples folder on my localhost. Had this README been there, I could have discovered what needed to be done quicker. Many devs might simply just move on instead of creating an issue. Sure, they could read through the entire README before testing, but that's not practical