### PR TITLE
fix: ensure correct rootstore address

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3box",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": "Interact with user data",
   "main": "lib/3box.js",
   "directories": {

--- a/src/3box.js
+++ b/src/3box.js
@@ -102,7 +102,9 @@ class Box extends BoxApi {
   async _load (opts = {}) {
     const address = opts.address || await this._3id.getAddress()
     const { rootStoreAddress, did } = address ? await this._getLinkedData(address) : {}
-    if (rootStoreAddress) {
+    // Check for ',' because a bug caused the incorrect rootstore to be linked.
+    // If so we create the correct one instead.
+    if (rootStoreAddress && !rootStoreAddress.includes(',')) {
       await this.replicator.start(rootStoreAddress, did, { profile: true })
       await this.replicator.rootstoreSyncDone
       const authData = await this.replicator.getAuthData()


### PR DESCRIPTION
Makes sure the linked rootstore address has the correct format.